### PR TITLE
Feature/fix firebase analytics without ad support

### DIFF
--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -26,7 +26,7 @@
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>10.24.0.1</PackageVersion>
+    <PackageVersion>10.24.0.2</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Core/Core.targets
+++ b/source/Firebase/Core/Core.targets
@@ -15,7 +15,7 @@
   <Target Name="_FCrDownloadedItems">
     <ItemGroup Condition="'$(FirebaseWithoutAdIdSupport)'!='True'">
       <!-- From https://dl.google.com/firebase/ios/analytics/cc4d75392af34c62/GoogleAppMeasurement-10.24.0.tar.gz -->
-      <NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurement.xcframework">
+      <NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurementIdentitySupport.xcframework">
         <Kind>Framework</Kind>
         <SmartLink>True</SmartLink>
         <ForceLoad>True</ForceLoad>
@@ -25,7 +25,7 @@
     </ItemGroup>
     <ItemGroup Condition="'$(FirebaseWithoutAdIdSupport)'=='True'">
       <!-- From https://dl.google.com/firebase/ios/analytics/cc4d75392af34c62/GoogleAppMeasurement-10.24.0.tar.gz -->
-      <NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurementWithoutAdIdSupport.xcframework">
+      <NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurement.xcframework">
         <Kind>Framework</Kind>
         <SmartLink>True</SmartLink>
         <ForceLoad>True</ForceLoad>


### PR DESCRIPTION
Fixed the path for folders required for enabling the [FirebaseWithoutAdIdSupport](https://github.com/xamarin/GoogleApisForiOSComponents?tab=readme-ov-file#ad-id-support).

@AdamEssenmacher do I need to change anything else to get this fix out asap?