### PR TITLE
Fix upload dSYM when using multiple GoogleService-Info.plist files

### DIFF
--- a/source/Firebase/Crashlytics/Crashlytics.targets
+++ b/source/Firebase/Crashlytics/Crashlytics.targets
@@ -5,7 +5,7 @@
     <_FirebaseCrashlyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseCrashlyticsItemsFolder)\</_FirebaseCrashlyticsSDKBaseFolder>
     <!-- Requires a file extension, otherwise XDB will complain  -->
     <_FirebaseScriptName>upload-symbols.sh</_FirebaseScriptName>
-    
+
     <_FirebaseCrashlyticsUploadSymbolsContinueOnError Condition="'$(FirebaseCrashlyticsUploadSymbolsContinueOnError)'=='True'">True</_FirebaseCrashlyticsUploadSymbolsContinueOnError>
     <_FirebaseCrashlyticsUploadSymbolsContinueOnError Condition="'$(FirebaseCrashlyticsUploadSymbolsContinueOnError)'!='True'">False</_FirebaseCrashlyticsUploadSymbolsContinueOnError>
 
@@ -35,10 +35,10 @@
   <Target Name="_FirebaseCrashlyticsUploadDSymToFirebaseOnMac" >
     <!-- Make file executable -->
     <Exec Command="chmod +x '$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)'" ContinueOnError="true" />
-    
+
     <Message Text="Uploading dSYM to Firebase Console using Firebase $(_FirebaseScriptName) script located at $(_FirebaseCrashlyticsSDKBaseFolder)" />
     <!-- Upload symbols to Firebase -->
-    <Exec Command="'$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)' -gsp '$(MSBuildProjectDirectory)\GoogleService-Info.plist' -p ios '$(MSBuildProjectDirectory)\$(DeviceSpecificOutputPath)$(AssemblyName).app.dSYM'"
+    <Exec Command="'$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)' -gsp '$(MSBuildProjectDirectory)\$(DeviceSpecificOutputPath)$(AssemblyName).app\GoogleService-Info.plist' -p ios '$(MSBuildProjectDirectory)\$(DeviceSpecificOutputPath)$(AssemblyName).app.dSYM'"
       ContinueOnError="$(_FirebaseCrashlyticsUploadSymbolsContinueOnError)" />
   </Target>
   <!-- Target to upload dSYM symbols to Firebase when using Visual Studio for Windows -->
@@ -47,16 +47,16 @@
       <_CopyFilesToMacOutput Include="$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)">
         <TargetPath>$(_FirebaseScriptName)</TargetPath>
       </_CopyFilesToMacOutput>
-    </ItemGroup>  
+    </ItemGroup>
 
     <Message Text="Copying Firebase $(_FirebaseScriptName) script located at $(_FirebaseCrashlyticsSDKBaseFolder) to Mac host" />
     <CopyFilesToBuildServer SessionId="$(BuildSessionId)" Files="@(_CopyFilesToMacOutput)" />
     <!-- Make file executable -->
     <Exec SessionId="$(BuildSessionId)" Command="chmod +x $(_FirebaseScriptName)" ContinueOnError="true" />
-    
+
     <Message Text="Uploading dSYM to Firebase Console using Firebase $(_FirebaseScriptName) script" />
     <!-- Upload symbols to Firebase -->
-    <Exec SessionId="$(BuildSessionId)" Command="'./$(_FirebaseScriptName)' -gsp './GoogleService-Info.plist' -p ios './$(DeviceSpecificOutputPath)$(AssemblyName).app.dSYM'" ContinueOnError="$(_FirebaseCrashlyticsUploadSymbolsContinueOnError)" />
+    <Exec SessionId="$(BuildSessionId)" Command="'./$(_FirebaseScriptName)' -gsp './$(DeviceSpecificOutputPath)$(AssemblyName).app/GoogleService-Info.plist' -p ios './$(DeviceSpecificOutputPath)$(AssemblyName).app.dSYM'" ContinueOnError="$(_FirebaseCrashlyticsUploadSymbolsContinueOnError)" />
   </Target>
   <PropertyGroup>
     <_FirebaseCrashlyticsId>FirebaseCrashlytics</_FirebaseCrashlyticsId>
@@ -66,7 +66,7 @@
       <_Id>$(_FirebaseCrashlyticsId)</_Id>
     </_NativeReference>
   </ItemGroup>
-  <Target Name="_ResolveNativeReferencesForFirebaseCrashlytics" 
+  <Target Name="_ResolveNativeReferencesForFirebaseCrashlytics"
           BeforeTargets="ResolveNativeReferences"
           Condition="('$(TargetFrameworks)' == '' AND '$(TargetFramework)' == '') OR '$(IsBindingProject)' == 'true'">
     <ItemGroup>

--- a/source/Firebase/Crashlytics/Crashlytics.targets
+++ b/source/Firebase/Crashlytics/Crashlytics.targets
@@ -5,7 +5,7 @@
     <_FirebaseCrashlyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseCrashlyticsItemsFolder)\</_FirebaseCrashlyticsSDKBaseFolder>
     <!-- Requires a file extension, otherwise XDB will complain  -->
     <_FirebaseScriptName>upload-symbols.sh</_FirebaseScriptName>
-
+    
     <_FirebaseCrashlyticsUploadSymbolsContinueOnError Condition="'$(FirebaseCrashlyticsUploadSymbolsContinueOnError)'=='True'">True</_FirebaseCrashlyticsUploadSymbolsContinueOnError>
     <_FirebaseCrashlyticsUploadSymbolsContinueOnError Condition="'$(FirebaseCrashlyticsUploadSymbolsContinueOnError)'!='True'">False</_FirebaseCrashlyticsUploadSymbolsContinueOnError>
 

--- a/source/Firebase/Crashlytics/Crashlytics.targets
+++ b/source/Firebase/Crashlytics/Crashlytics.targets
@@ -35,7 +35,7 @@
   <Target Name="_FirebaseCrashlyticsUploadDSymToFirebaseOnMac" >
     <!-- Make file executable -->
     <Exec Command="chmod +x '$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)'" ContinueOnError="true" />
-
+    
     <Message Text="Uploading dSYM to Firebase Console using Firebase $(_FirebaseScriptName) script located at $(_FirebaseCrashlyticsSDKBaseFolder)" />
     <!-- Upload symbols to Firebase -->
     <Exec Command="'$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)' -gsp '$(MSBuildProjectDirectory)\$(DeviceSpecificOutputPath)$(AssemblyName).app\GoogleService-Info.plist' -p ios '$(MSBuildProjectDirectory)\$(DeviceSpecificOutputPath)$(AssemblyName).app.dSYM'"
@@ -47,13 +47,13 @@
       <_CopyFilesToMacOutput Include="$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)">
         <TargetPath>$(_FirebaseScriptName)</TargetPath>
       </_CopyFilesToMacOutput>
-    </ItemGroup>
+    </ItemGroup>  
 
     <Message Text="Copying Firebase $(_FirebaseScriptName) script located at $(_FirebaseCrashlyticsSDKBaseFolder) to Mac host" />
     <CopyFilesToBuildServer SessionId="$(BuildSessionId)" Files="@(_CopyFilesToMacOutput)" />
     <!-- Make file executable -->
     <Exec SessionId="$(BuildSessionId)" Command="chmod +x $(_FirebaseScriptName)" ContinueOnError="true" />
-
+    
     <Message Text="Uploading dSYM to Firebase Console using Firebase $(_FirebaseScriptName) script" />
     <!-- Upload symbols to Firebase -->
     <Exec SessionId="$(BuildSessionId)" Command="'./$(_FirebaseScriptName)' -gsp './$(DeviceSpecificOutputPath)$(AssemblyName).app/GoogleService-Info.plist' -p ios './$(DeviceSpecificOutputPath)$(AssemblyName).app.dSYM'" ContinueOnError="$(_FirebaseCrashlyticsUploadSymbolsContinueOnError)" />
@@ -66,7 +66,7 @@
       <_Id>$(_FirebaseCrashlyticsId)</_Id>
     </_NativeReference>
   </ItemGroup>
-  <Target Name="_ResolveNativeReferencesForFirebaseCrashlytics"
+  <Target Name="_ResolveNativeReferencesForFirebaseCrashlytics" 
           BeforeTargets="ResolveNativeReferences"
           Condition="('$(TargetFrameworks)' == '' AND '$(TargetFramework)' == '') OR '$(IsBindingProject)' == 'true'">
     <ItemGroup>


### PR DESCRIPTION
Fix upload dSYM when using multiple GoogleService-Info.plist files based on build configuration by using the final app bundle to locate the GoogleService-Info.plist file when uploading symbols to Firebase.