### PR TITLE
Fix GoogleAppMeasurement NativeReference correctly in Core.targets

### DIFF
--- a/source/Firebase/Core/Core.targets
+++ b/source/Firebase/Core/Core.targets
@@ -15,6 +15,13 @@
   <Target Name="_FCrDownloadedItems">
     <ItemGroup Condition="'$(FirebaseWithoutAdIdSupport)'!='True'">
       <!-- From https://dl.google.com/firebase/ios/analytics/cc4d75392af34c62/GoogleAppMeasurement-10.24.0.tar.gz -->
+      <NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurement.xcframework">
+        <Kind>Framework</Kind>
+        <SmartLink>True</SmartLink>
+        <ForceLoad>True</ForceLoad>
+        <LinkerFlags>-ObjC -lc++ -lsqlite3 -lz</LinkerFlags>
+        <Frameworks>StoreKit</Frameworks>
+      </NativeReference>
       <NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurementIdentitySupport.xcframework">
         <Kind>Framework</Kind>
         <SmartLink>True</SmartLink>
@@ -23,7 +30,7 @@
         <Frameworks>StoreKit</Frameworks>
       </NativeReference>
     </ItemGroup>
-    <ItemGroup>
+    <ItemGroup Condition="'$(FirebaseWithoutAdIdSupport)'=='True'">
       <!-- From https://dl.google.com/firebase/ios/analytics/cc4d75392af34c62/GoogleAppMeasurement-10.24.0.tar.gz -->
       <NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurement.xcframework">
         <Kind>Framework</Kind>


### PR DESCRIPTION
Looking at the release notes of the Firebase Apple SDK, all the way back to [8.8.0](https://firebase.google.com/support/release-notes/ios#analytics_33), we can see the following being stated:

> Increased minimum required CocoaPods version to 1.10.2 to refactor AdSupport-related code out of GoogleAppMeasurement.xcframework to an optional GoogleAppMeasurementIdentitySupport.xcframework dependency.
> 
> GoogleAppMeasurement/WithoutAdIdSupport subspec now ships GoogleAppMeasurement.xcframework. GoogleAppMeasurement/AdIdSupport subspec ships both GoogleAppMeasurement.xcframework and GoogleAppMeasurementIdentitySupport.xcframework.

Here you can clearly see that "WithoutAdIdSupport" only ships `GoogleAppMeasurement.xcframework`, while "AdIdSupport" is supposed to ship both `GoogleAppMeasurement.xcframework` AND `GoogleAppMeasurementIdentitySupport.xcframework`. According to the first paragraph, `GoogleAppMeasurement.xcframework` is the base framework while `GoogleAppMeasurementIdentitySupport.xcframework` is meant to be an optional dependency on top of the base framework which cointaints the AdSupport-related code.

This should fix #35 and #40 correctly.