### PR TITLE
Fix obsolete and missing resources in Maps.targets for GoogleMaps 9.1.1

### DIFF
--- a/source/Google/Maps/Maps.targets
+++ b/source/Google/Maps/Maps.targets
@@ -63,18 +63,6 @@
         <LogicalName>GoogleMaps.bundle\bubble_right@3x.png</LogicalName>
         <Optimize>False</Optimize>
       </BundleResource>
-      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)default_marker.png" Visible="False">
-        <LogicalName>GoogleMaps.bundle\default_marker.png</LogicalName>
-        <Optimize>False</Optimize>
-      </BundleResource>
-      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)default_marker@2x.png" Visible="False">
-        <LogicalName>GoogleMaps.bundle\default_marker@2x.png</LogicalName>
-        <Optimize>False</Optimize>
-      </BundleResource>
-      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)default_marker@3x.png" Visible="False">
-        <LogicalName>GoogleMaps.bundle\default_marker@3x.png</LogicalName>
-        <Optimize>False</Optimize>
-      </BundleResource>
       <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)ic_error.png" Visible="False">
         <LogicalName>GoogleMaps.bundle\ic_error.png</LogicalName>
         <Optimize>False</Optimize>
@@ -368,6 +356,24 @@
       <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\measle_blank_small@3x.png" Visible="False">
         <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\measle_blank_small@3x.png</LogicalName>
       </BundleResource>
+      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\measle_blank_tiny.png" Visible="False">
+        <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\measle_blank_tiny.png</LogicalName>
+      </BundleResource>
+      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\measle_blank_tiny@2x.png" Visible="False">
+        <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\measle_blank_tiny@2x.png</LogicalName>
+      </BundleResource>
+      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\measle_blank_tiny@3x.png" Visible="False">
+        <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\measle_blank_tiny@3x.png</LogicalName>
+      </BundleResource>
+      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\measle_blank.png" Visible="False">
+        <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\measle_blank.png</LogicalName>
+      </BundleResource>
+      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\measle_blank@2x.png" Visible="False">
+        <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\measle_blank@2x.png</LogicalName>
+      </BundleResource>
+      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\measle_blank@3x.png" Visible="False">
+        <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\measle_blank@3x.png</LogicalName>
+      </BundleResource>
       <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\measle_C.png" Visible="False">
         <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\measle_C.png</LogicalName>
       </BundleResource>
@@ -582,9 +588,6 @@
       </BundleResource>
       <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\lt.lproj\GMSCore.strings" Visible="False">
         <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\lt.lproj\GMSCore.strings</LogicalName>
-      </BundleResource>
-      <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\lv.lproj\GMSCore.strings" Visible="False">
-        <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\lv.lproj\GMSCore.strings</LogicalName>
       </BundleResource>
       <BundleResource Include="$(_GoogleMapsResourcesBaseFolder)GMSCoreResources.bundle\ms.lproj\GMSCore.strings" Visible="False">
         <LogicalName>GoogleMaps.bundle\GMSCoreResources.bundle\ms.lproj\GMSCore.strings</LogicalName>


### PR DESCRIPTION
This fixes #50 and adds missing resources that were overlooked