### PR TITLE
[codex] Fix Firestore GetQueryNamed runtime drift

### DIFF
--- a/docs/firebase-runtime-failure-backlog.md
+++ b/docs/firebase-runtime-failure-backlog.md
@@ -1,0 +1,17 @@
+# Firebase Runtime Failure Backlog
+
+This backlog tracks binding drifts that are concrete candidates for the runtime-failure remediation loop.
+
+## Ready
+
+| Case id | Target/member | Audit finding reference | Expected runtime failure mechanism | Proof status | Fix PR | Merged commit |
+| --- | --- | --- | --- | --- | --- | --- |
+| `cloudfirestore-getquerynamed` | `Firebase.CloudFirestore.Firestore.GetQueryNamed` | `output/firebase-binding-audit/report.json` -> `CloudFirestore` -> `GetQueryNamed` (`signature-drift`) | The binding currently exports `getQueryNamed:completion:` as `NSInputStream` instead of `NSString`, so native Firestore receives `__NSCFInputStream` and throws an Objective-C exception when it treats the argument like a string. | Proved locally on the unfixed binding. Evidence: `ObjCRuntime.ObjCException`, `NSInvalidArgumentException`, selector `-[__NSCFInputStream length]`, artifact `tests/E2E/Firebase.Foundation/artifacts/firebase-foundation-result-cloudfirestore-getquerynamed-failure.json`, log `tests/E2E/Firebase.Foundation/artifacts/firebase-foundation-sim-cloudfirestore-getquerynamed-failure.log`. | Pending | - |
+
+## Investigating
+
+No additional runtime-failure candidates are currently promoted.
+
+## Done
+
+None yet.

--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -448,7 +448,7 @@ namespace Firebase.CloudFirestore
 
 		// - (void)getQueryNamed:(NSString *)name completion:(void (^)(FIRQuery *_Nullable query))completion
 		[Export ("getQueryNamed:completion:")]
-		void GetQueryNamed (NSInputStream bundleStream, Action<Query> completion);
+		void GetQueryNamed (string name, Action<Query> completion);
 	}
 
 	// @interface FIRTimestamp : NSObject <NSCopying>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
@@ -15,7 +15,12 @@
     <IsPackable>false</IsPackable>
     <ProvisioningType>manual</ProvisioningType>
     <EnableNullabilityValidation>false</EnableNullabilityValidation>
+    <RuntimeDriftCase></RuntimeDriftCase>
+    <RuntimeDriftCaseMethod></RuntimeDriftCaseMethod>
+    <RuntimeDriftCasePropsPath></RuntimeDriftCasePropsPath>
   </PropertyGroup>
+
+  <Import Project="$(RuntimeDriftCasePropsPath)" Condition="'$(RuntimeDriftCasePropsPath)' != '' and Exists('$(RuntimeDriftCasePropsPath)')" />
 
   <PropertyGroup Condition="'$(EnableNullabilityValidation)' == 'true'">
     <DefineConstants>$(DefineConstants);ENABLE_NULLABILITY_VALIDATION</DefineConstants>
@@ -40,6 +45,17 @@
   <ItemGroup>
     <None Remove="GoogleService-Info.plist" Condition="Exists('GoogleService-Info.plist')" />
     <BundleResource Include="GoogleService-Info.plist" Condition="Exists('GoogleService-Info.plist')" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RuntimeDriftCase)' != ''">
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>RuntimeDriftCase</_Parameter1>
+      <_Parameter2>$(RuntimeDriftCase)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(RuntimeDriftCaseMethod)' != ''">
+      <_Parameter1>RuntimeDriftCaseMethod</_Parameter1>
+      <_Parameter2>$(RuntimeDriftCaseMethod)</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -1,0 +1,143 @@
+using System.Reflection;
+
+#if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFIRESTORE_GETQUERYNAMED
+using Firebase.CloudFirestore;
+using Foundation;
+using ObjCRuntime;
+#endif
+
+namespace FirebaseFoundationE2E;
+
+static class FirebaseRuntimeDriftCases
+{
+    static readonly TimeSpan AsyncTimeout = TimeSpan.FromSeconds(5);
+
+    public static string? GetConfiguredCaseId()
+    {
+        return GetAssemblyMetadataValue("RuntimeDriftCase");
+    }
+
+    public static async Task<string> ExecuteConfiguredCaseAsync()
+    {
+        var caseId = GetConfiguredCaseId();
+        if (string.IsNullOrWhiteSpace(caseId))
+        {
+            throw new InvalidOperationException("Runtime drift mode was requested without a RuntimeDriftCase value.");
+        }
+
+        var methodName = GetAssemblyMetadataValue("RuntimeDriftCaseMethod");
+        if (string.IsNullOrWhiteSpace(methodName))
+        {
+            throw new InvalidOperationException($"Runtime drift case '{caseId}' is missing RuntimeDriftCaseMethod metadata.");
+        }
+
+        var method = typeof(FirebaseRuntimeDriftCases).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
+        if (method is null)
+        {
+            throw new InvalidOperationException($"Runtime drift case '{caseId}' points at missing method '{methodName}'.");
+        }
+
+        if (method.Invoke(null, null) is not Task<string> task)
+        {
+            throw new InvalidOperationException($"Runtime drift case '{caseId}' method '{methodName}' did not return Task<string>.");
+        }
+
+        return await task;
+    }
+
+    static string? GetAssemblyMetadataValue(string key)
+    {
+        return typeof(FirebaseRuntimeDriftCases)
+            .Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(attribute => string.Equals(attribute.Key, key, StringComparison.Ordinal))
+            ?.Value;
+    }
+
+#if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFIRESTORE_GETQUERYNAMED
+    static async Task<string> VerifyCloudFirestoreGetQueryNamedAsync()
+    {
+        const string selector = "getQueryNamed:completion:";
+
+        var firestore = Firestore.SharedInstance;
+        if (firestore is null)
+        {
+            throw new InvalidOperationException("Firebase.CloudFirestore.Firestore.SharedInstance returned null after App.Configure().");
+        }
+
+        var queryName = "codex-firestore-missing-query";
+        var callbackInvoked = false;
+        var returnedQueryWasNull = false;
+        NSException? marshaledException = null;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+        var completionSource = new TaskCompletionSource<Query?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledException ??= args.Exception;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            try
+            {
+                firestore.GetQueryNamed(queryName, query =>
+                {
+                    callbackInvoked = true;
+                    returnedQueryWasNull = query is null;
+                    completionSource.TrySetResult(query);
+                });
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' should not throw after the binding fix, but observed {ex.GetType().FullName}. " +
+                    $"Runtime argument type: {queryName.GetType().FullName}. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            var completedTask = await Task.WhenAny(completionSource.Task, Task.Delay(AsyncTimeout));
+            if (completedTask != completionSource.Task)
+            {
+                throw new TimeoutException(
+                    $"Selector '{selector}' did not invoke its completion callback within {AsyncTimeout.TotalSeconds} seconds after the binding fix.");
+            }
+
+            var returnedQuery = await completionSource.Task;
+            if (!callbackInvoked)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' completed without throwing, but the completion callback was never marked as invoked.");
+            }
+
+            if (marshaledException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
+                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            return
+                $"Selector '{selector}' completed without ObjC exception after the binding fix. " +
+                $"Runtime argument type: {queryName.GetType().FullName}. " +
+                $"CallbackInvoked: {callbackInvoked}. " +
+                $"ReturnedQueryWasNull: {returnedQueryWasNull}. " +
+                $"ReturnedQueryType: {returnedQuery?.GetType().FullName ?? "<null>"}.";
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
+#endif
+
+    static string FormatDetail(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "<empty>" : value;
+    }
+}

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseSelfTestRunner.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseSelfTestRunner.cs
@@ -26,6 +26,11 @@ public static class FirebaseSelfTestRunner
 #if ENABLE_NULLABILITY_VALIDATION
         await statusViewController.AppendLineAsync("Firebase nullability validation mode enabled.");
 #endif
+        var runtimeDriftCase = FirebaseRuntimeDriftCases.GetConfiguredCaseId();
+        if (!string.IsNullOrWhiteSpace(runtimeDriftCase))
+        {
+            await statusViewController.AppendLineAsync($"Runtime drift case mode enabled: {runtimeDriftCase}");
+        }
 
         try
         {
@@ -44,74 +49,82 @@ public static class FirebaseSelfTestRunner
                 return $"Configured app '{defaultApp.Name}'.";
             });
 
-            await ExecuteCaseAsync(result, statusViewController, "CoreSurface", async () =>
+            if (!string.IsNullOrWhiteSpace(runtimeDriftCase))
             {
-                var defaultApp = App.DefaultInstance ?? throw new InvalidOperationException("Firebase.Core.App.DefaultInstance returned null.");
-                var firebaseVersion = App.FirebaseVersion;
-
-                if (string.IsNullOrWhiteSpace(firebaseVersion))
+                await ExecuteCaseAsync(result, statusViewController, $"RuntimeDrift:{runtimeDriftCase}", () =>
+                    FirebaseRuntimeDriftCases.ExecuteConfiguredCaseAsync());
+            }
+            else
+            {
+                await ExecuteCaseAsync(result, statusViewController, "CoreSurface", async () =>
                 {
-                    throw new InvalidOperationException("Firebase.Core.App.FirebaseVersion returned an empty value.");
-                }
+                    var defaultApp = App.DefaultInstance ?? throw new InvalidOperationException("Firebase.Core.App.DefaultInstance returned null.");
+                    var firebaseVersion = App.FirebaseVersion;
 
-                result.FirebaseVersion = firebaseVersion;
-                return $"Firebase version: {firebaseVersion}; app name: {defaultApp.Name}.";
-            });
+                    if (string.IsNullOrWhiteSpace(firebaseVersion))
+                    {
+                        throw new InvalidOperationException("Firebase.Core.App.FirebaseVersion returned an empty value.");
+                    }
+
+                    result.FirebaseVersion = firebaseVersion;
+                    return $"Firebase version: {firebaseVersion}; app name: {defaultApp.Name}.";
+                });
 
 #if ENABLE_NULLABILITY_VALIDATION
-            await ExecuteCaseAsync(result, statusViewController, "CoreNullabilitySurface", () =>
-                FirebaseNullabilityValidation.VerifyCoreNullabilityAsync());
+                await ExecuteCaseAsync(result, statusViewController, "CoreNullabilitySurface", () =>
+                    FirebaseNullabilityValidation.VerifyCoreNullabilityAsync());
 
-            await ExecuteCaseAsync(result, statusViewController, "AnalyticsNullabilitySurface", () =>
-                FirebaseNullabilityValidation.VerifyAnalyticsNullabilityAsync());
+                await ExecuteCaseAsync(result, statusViewController, "AnalyticsNullabilitySurface", () =>
+                    FirebaseNullabilityValidation.VerifyAnalyticsNullabilityAsync());
 
-            await ExecuteCaseAsync(result, statusViewController, "AppCheckNullabilitySurface", () =>
-                FirebaseNullabilityValidation.VerifyAppCheckNullabilityAsync());
+                await ExecuteCaseAsync(result, statusViewController, "AppCheckNullabilitySurface", () =>
+                    FirebaseNullabilityValidation.VerifyAppCheckNullabilityAsync());
 
-            await ExecuteCaseAsync(result, statusViewController, "CloudMessagingNullabilitySurface", () =>
-                FirebaseNullabilityValidation.VerifyCloudMessagingNullabilityAsync());
+                await ExecuteCaseAsync(result, statusViewController, "CloudMessagingNullabilitySurface", () =>
+                    FirebaseNullabilityValidation.VerifyCloudMessagingNullabilityAsync());
 
-            await ExecuteCaseAsync(result, statusViewController, "CloudFirestoreNullabilitySurface", () =>
-                FirebaseNullabilityValidation.VerifyCloudFirestoreNullabilityAsync());
+                await ExecuteCaseAsync(result, statusViewController, "CloudFirestoreNullabilitySurface", () =>
+                    FirebaseNullabilityValidation.VerifyCloudFirestoreNullabilityAsync());
 
-            await ExecuteCaseAsync(result, statusViewController, "CrashlyticsNullabilitySurface", () =>
-                FirebaseNullabilityValidation.VerifyCrashlyticsNullabilityAsync());
+                await ExecuteCaseAsync(result, statusViewController, "CrashlyticsNullabilitySurface", () =>
+                    FirebaseNullabilityValidation.VerifyCrashlyticsNullabilityAsync());
 
-            await ExecuteCaseAsync(result, statusViewController, "DatabaseNullabilitySurface", () =>
-                FirebaseNullabilityValidation.VerifyDatabaseNullabilityAsync());
+                await ExecuteCaseAsync(result, statusViewController, "DatabaseNullabilitySurface", () =>
+                    FirebaseNullabilityValidation.VerifyDatabaseNullabilityAsync());
 
-            await ExecuteCaseAsync(result, statusViewController, "PerformanceNullabilitySurface", () =>
-                FirebaseNullabilityValidation.VerifyPerformanceNullabilityAsync());
+                await ExecuteCaseAsync(result, statusViewController, "PerformanceNullabilitySurface", () =>
+                    FirebaseNullabilityValidation.VerifyPerformanceNullabilityAsync());
 #endif
 
-            await ExecuteCaseAsync(result, statusViewController, "InstallationsSurface", async () =>
-            {
-                var installations = Installations.DefaultInstance ?? throw new InvalidOperationException("Firebase.Installations.Installations.DefaultInstance returned null.");
-                var installationId = await GetInstallationIdAsync(installations);
-                result.InstallationsIdPreview = installationId.Length > 16
-                    ? installationId[..8] + "..." + installationId[^8..]
-                    : installationId;
-                return $"Installation id: {result.InstallationsIdPreview}.";
-            });
-
-            await ExecuteCaseAsync(result, statusViewController, "AnalyticsSurface", async () =>
-            {
-                Analytics.SetAnalyticsCollectionEnabled(true);
-                Analytics.SetConsent(new Dictionary<ConsentType, ConsentStatus>
+                await ExecuteCaseAsync(result, statusViewController, "InstallationsSurface", async () =>
                 {
-                    [ConsentType.AnalyticsStorage] = ConsentStatus.Granted,
-                    [ConsentType.AdStorage] = ConsentStatus.Denied,
+                    var installations = Installations.DefaultInstance ?? throw new InvalidOperationException("Firebase.Installations.Installations.DefaultInstance returned null.");
+                    var installationId = await GetInstallationIdAsync(installations);
+                    result.InstallationsIdPreview = installationId.Length > 16
+                        ? installationId[..8] + "..." + installationId[^8..]
+                        : installationId;
+                    return $"Installation id: {result.InstallationsIdPreview}.";
                 });
 
-                Analytics.LogEvent(EventNamesConstants.ScreenView.ToString(), new Dictionary<object, object>
+                await ExecuteCaseAsync(result, statusViewController, "AnalyticsSurface", async () =>
                 {
-                    [ParameterNamesConstants.ScreenName] = new NSString("firebase_nuget_e2e"),
-                    [ParameterNamesConstants.ScreenClass] = new NSString(nameof(FirebaseSelfTestRunner)),
-                    [ParameterNamesConstants.Success] = NSNumber.FromBoolean(true),
-                });
+                    Analytics.SetAnalyticsCollectionEnabled(true);
+                    Analytics.SetConsent(new Dictionary<ConsentType, ConsentStatus>
+                    {
+                        [ConsentType.AnalyticsStorage] = ConsentStatus.Granted,
+                        [ConsentType.AdStorage] = ConsentStatus.Denied,
+                    });
 
-                return "Analytics collection and event APIs completed without throwing.";
-            });
+                    Analytics.LogEvent(EventNamesConstants.ScreenView.ToString(), new Dictionary<object, object>
+                    {
+                        [ParameterNamesConstants.ScreenName] = new NSString("firebase_nuget_e2e"),
+                        [ParameterNamesConstants.ScreenClass] = new NSString(nameof(FirebaseSelfTestRunner)),
+                        [ParameterNamesConstants.Success] = NSNumber.FromBoolean(true),
+                    });
+
+                    return "Analytics collection and event APIs completed without throwing.";
+                });
+            }
         }
         catch (Exception ex)
         {

--- a/tests/E2E/Firebase.Foundation/README.md
+++ b/tests/E2E/Firebase.Foundation/README.md
@@ -80,3 +80,15 @@ dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.Analytics,Fireba
 ```sh
 tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --enable-nullability-validation
 ```
+
+## Targeted runtime drift mode
+
+The harness also supports a targeted runtime-drift lane for one binding drift at a time. This mode runs only `ConfigureApp` plus the selected drift case, so each remediation PR can prove the unfixed runtime failure locally, then keep only the success-oriented regression test in the final diff.
+
+The checked-in case manifest lives at [`runtime-drift-cases.json`](./runtime-drift-cases.json), and the backlog/queue is tracked in [`docs/firebase-runtime-failure-backlog.md`](../../docs/firebase-runtime-failure-backlog.md).
+
+Run a specific drift case with:
+
+```sh
+tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case cloudfirestore-getquerynamed
+```

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -1,0 +1,15 @@
+{
+  "cases": [
+    {
+      "id": "cloudfirestore-getquerynamed",
+      "method": "VerifyCloudFirestoreGetQueryNamedAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.CloudFirestore",
+      "packages": [
+        {
+          "id": "AdamE.Firebase.iOS.CloudFirestore",
+          "version": "12.6.0"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/e2e/run-firebase-foundation.sh
+++ b/tools/e2e/run-firebase-foundation.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: tools/e2e/run-firebase-foundation.sh [--package-dir output] [--configuration Release] [--enable-nullability-validation]
+Usage: tools/e2e/run-firebase-foundation.sh [--package-dir output] [--configuration Release] [--enable-nullability-validation] [--runtime-drift-case <id>]
 EOF
 }
 
@@ -13,12 +13,18 @@ project_file="$project_dir/FirebaseFoundationE2E.csproj"
 bundle_id="com.googleapisforioscomponents.tests.firebase.e2e"
 configuration="Release"
 enable_nullability_validation="false"
+runtime_drift_case=""
 package_dir="$repo_root/output"
 artifacts_dir="$repo_root/tests/E2E/Firebase.Foundation/artifacts"
 log_file="$artifacts_dir/firebase-foundation-sim.log"
 result_file="$artifacts_dir/firebase-foundation-result.json"
 restore_config="$artifacts_dir/NuGet.generated.config"
 repo_restore_config="$repo_root/tests/E2E/Firebase.Foundation/NuGet.config"
+runtime_drift_manifest="$repo_root/tests/E2E/Firebase.Foundation/runtime-drift-cases.json"
+runtime_drift_props="$artifacts_dir/runtime-drift-case.generated.props"
+runtime_drift_info="$artifacts_dir/runtime-drift-case.info"
+runtime_drift_method=""
+runtime_drift_binding_package=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -33,6 +39,10 @@ while [[ $# -gt 0 ]]; do
     --enable-nullability-validation)
       enable_nullability_validation="true"
       shift
+      ;;
+    --runtime-drift-case)
+      runtime_drift_case="$2"
+      shift 2
       ;;
     --help|-h)
       usage
@@ -52,6 +62,11 @@ fi
 
 mkdir -p "$artifacts_dir"
 : > "$log_file"
+
+if [[ "$enable_nullability_validation" == "true" && -n "$runtime_drift_case" ]]; then
+  echo "--enable-nullability-validation and --runtime-drift-case cannot be used together." >&2
+  exit 1
+fi
 
 required_packages=(
   "AdamE.Firebase.iOS.Core"
@@ -75,6 +90,75 @@ if [[ "$enable_nullability_validation" == "true" ]]; then
     "AdamE.Firebase.iOS.PerformanceMonitoring"
   )
   msbuild_args+=("-p:EnableNullabilityValidation=true")
+fi
+
+if [[ -n "$runtime_drift_case" ]]; then
+  if [[ ! -f "$runtime_drift_manifest" ]]; then
+    echo "Missing runtime drift manifest: $runtime_drift_manifest" >&2
+    exit 1
+  fi
+
+  python3 - "$runtime_drift_manifest" "$runtime_drift_case" "$runtime_drift_props" > "$runtime_drift_info" <<'PY'
+import json
+import pathlib
+import re
+import sys
+from xml.sax.saxutils import escape
+
+manifest_path = pathlib.Path(sys.argv[1])
+case_id = sys.argv[2]
+props_path = pathlib.Path(sys.argv[3])
+manifest = json.loads(manifest_path.read_text())
+
+case = next((entry for entry in manifest.get("cases", []) if entry.get("id") == case_id), None)
+if case is None:
+    available = ", ".join(sorted(entry.get("id", "<missing>") for entry in manifest.get("cases", [])))
+    raise SystemExit(f"Unknown runtime drift case '{case_id}'. Available cases: {available}")
+
+method = case.get("method")
+binding_package = case.get("bindingPackage")
+packages = case.get("packages", [])
+
+if not method or not binding_package or not packages:
+    raise SystemExit(f"Runtime drift case '{case_id}' is missing required manifest fields.")
+
+symbol = "ENABLE_RUNTIME_DRIFT_CASE_" + re.sub(r"[^A-Za-z0-9]+", "_", case_id).strip("_").upper()
+props_path.write_text(
+    "<Project>\n"
+    "  <PropertyGroup>\n"
+    f"    <RuntimeDriftCase>{escape(case_id)}</RuntimeDriftCase>\n"
+    f"    <RuntimeDriftCaseMethod>{escape(method)}</RuntimeDriftCaseMethod>\n"
+    f"    <DefineConstants>$(DefineConstants);ENABLE_RUNTIME_DRIFT_CASE;{escape(symbol)}</DefineConstants>\n"
+    "  </PropertyGroup>\n"
+    "  <ItemGroup>\n"
+    + "".join(
+        f"    <PackageReference Include=\"{escape(package['id'])}\" Version=\"{escape(package['version'])}\" />\n"
+        for package in packages
+    )
+    + "  </ItemGroup>\n"
+    "</Project>\n"
+)
+
+print(method)
+print(binding_package)
+for package in packages:
+    print(package["id"])
+PY
+
+  runtime_drift_details=("${(@f)$(<"$runtime_drift_info")}")
+  runtime_drift_method="${runtime_drift_details[1]}"
+  runtime_drift_binding_package="${runtime_drift_details[2]}"
+  for (( i = 3; i <= ${#runtime_drift_details[@]}; i++ )); do
+    required_packages+=("${runtime_drift_details[$i]}")
+  done
+
+  msbuild_args+=(
+    "-p:RuntimeDriftCase=$runtime_drift_case"
+    "-p:RuntimeDriftCaseMethod=$runtime_drift_method"
+    "-p:RuntimeDriftCasePropsPath=$runtime_drift_props"
+  )
+
+  echo "Runtime drift case: $runtime_drift_case ($runtime_drift_binding_package)"
 fi
 
 for package_name in "${required_packages[@]}"; do


### PR DESCRIPTION
## Summary

This PR starts the runtime-failure drift remediation loop with the first concrete case: `cloudfirestore-getquerynamed`.

It does three things:

- fixes the Firestore binding for `getQueryNamed:completion:` so it binds `NSString` as `string` instead of `NSInputStream`
- adds a reusable targeted E2E mode (`--runtime-drift-case <id>`) for one drift case at a time
- adds a checked-in backlog and case manifest so future runtime-failure drifts can follow the same proof/fix/verify pattern

## Runtime failure proof before the fix

I first ran the new targeted lane against the unfixed binding locally:

```sh
tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case cloudfirestore-getquerynamed
```

That produced the expected binding-layer failure proof in:

- `tests/E2E/Firebase.Foundation/artifacts/firebase-foundation-result-cloudfirestore-getquerynamed-failure.json`
- `tests/E2E/Firebase.Foundation/artifacts/firebase-foundation-sim-cloudfirestore-getquerynamed-failure.log`

The captured evidence was:

- selector: `getQueryNamed:completion:`
- runtime argument type: `Foundation.NSInputStream`
- managed exception: `ObjCRuntime.ObjCException`
- native exception: `NSInvalidArgumentException`
- native reason: `-[__NSCFInputStream length]: unrecognized selector sent to instance ...`

## Fix and regression validation

After fixing the binding, I reran the same targeted lane and it passed:

- `tests/E2E/Firebase.Foundation/artifacts/firebase-foundation-result-cloudfirestore-getquerynamed-success.json`
- `tests/E2E/Firebase.Foundation/artifacts/firebase-foundation-sim-cloudfirestore-getquerynamed-success.log`

The success result shows:

- selector `getQueryNamed:completion:` completed without `ObjCException`
- runtime argument type: `System.String`
- callback invoked: `True`
- returned query was null for the unknown named query: `True`

I also reran the default smoke lane to ensure the new targeted-mode plumbing did not break the ordinary E2E harness.

## Validation

Commands used locally:

```sh
dotnet tool restore
dotnet pack source/Firebase/CloudFirestore/CloudFirestore.csproj --configuration Release --output output
tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case cloudfirestore-getquerynamed
tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug
```

## Notes

- The backlog entry stays under `Ready` in this PR and should move to `Done` only after merge, per the loop rules.
- This PR is intentionally scoped to one runtime-failure drift plus the reusable harness needed to repeat the process.
