### PR TITLE
Add Firebase Database ServerValue increment binding

### DIFF
--- a/source/Firebase/Database/ApiDefinition.cs
+++ b/source/Firebase/Database/ApiDefinition.cs
@@ -595,6 +595,11 @@ namespace Firebase.Database
 		[Static]
 		[Export ("timestamp")]
 		NSDictionary Timestamp { get; }
+
+		// +(NSDictionary * _Nonnull)increment:(NSNumber * _Nonnull)delta;
+		[Static]
+		[Export ("increment:")]
+		NSDictionary Increment (NSNumber delta);
 	}
 
 	// @interface FIRTransactionResult : NSObject

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -1,5 +1,11 @@
 using System.Reflection;
 
+#if ENABLE_RUNTIME_DRIFT_CASE_DATABASE_SERVERVALUE_INCREMENT
+using Firebase.Database;
+using Foundation;
+using ObjCRuntime;
+#endif
+
 #if ENABLE_RUNTIME_DRIFT_CASE_ABTESTING_UPDATEEXPERIMENTS
 using Firebase.ABTesting;
 using Foundation;
@@ -77,6 +83,75 @@ static class FirebaseRuntimeDriftCases
             .FirstOrDefault(attribute => string.Equals(attribute.Key, key, StringComparison.Ordinal))
             ?.Value;
     }
+
+#if ENABLE_RUNTIME_DRIFT_CASE_DATABASE_SERVERVALUE_INCREMENT
+    static Task<string> VerifyDatabaseServerValueIncrementAsync()
+    {
+        const string selector = "increment:";
+
+        var signature = typeof(ServerValue).GetMethod(
+            nameof(ServerValue.Increment),
+            BindingFlags.Static | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(NSNumber) },
+            modifiers: null);
+        if (signature is null)
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{nameof(ServerValue.Increment)}({typeof(NSNumber).FullName})' was not found.");
+        }
+
+        using var delta = NSNumber.FromInt64(1);
+        NSException? marshaledException = null;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledException ??= args.Exception;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            NSDictionary placeholder;
+            try
+            {
+                placeholder = ServerValue.Increment(delta);
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' should not throw for a valid NSNumber delta, but observed {ex.GetType().FullName}. " +
+                    $"Managed delta argument type: {delta.GetType().FullName}. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            if (marshaledException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
+                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            if (placeholder.Count == 0)
+            {
+                throw new InvalidOperationException("ServerValue.Increment returned an empty placeholder dictionary.");
+            }
+
+            return Task.FromResult(
+                $"Selector '{selector}' returned a non-empty placeholder dictionary. " +
+                $"Managed delta argument type: {delta.GetType().FullName}. Placeholder count: {placeholder.Count}.");
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
+#endif
 
 #if ENABLE_RUNTIME_DRIFT_CASE_ABTESTING_UPDATEEXPERIMENTS
     static async Task<string> VerifyABTestingUpdateExperimentsAsync()

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -1,6 +1,17 @@
 {
   "cases": [
     {
+      "id": "database-servervalue-increment",
+      "method": "VerifyDatabaseServerValueIncrementAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.Database",
+      "packages": [
+        {
+          "id": "AdamE.Firebase.iOS.Database",
+          "version": "12.6.0"
+        }
+      ]
+    },
+    {
       "id": "abtesting-updateexperiments",
       "method": "VerifyABTestingUpdateExperimentsAsync",
       "bindingPackage": "AdamE.Firebase.iOS.ABTesting",


### PR DESCRIPTION
## Summary
- add the missing `Firebase.Database.ServerValue.Increment(NSNumber)` binding for native `+[FIRServerValue increment:]`
- add a targeted local E2E drift case that verifies the binding exists and returns a non-empty server-value placeholder dictionary

## Why
`FIRServerValue.increment:` exists in the Firebase Database 12.6 headers, but the managed binding only exposed `ServerValue.Timestamp`. That means consumers could not use Firebase's atomic increment placeholder through the current binding.

## Validation
- `dotnet pack source/Firebase/Database/Database.csproj --configuration Release --output output`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case database-servervalue-increment`

The default smoke lane was also attempted, but the local simulator build stalled in the AOT/clang build phase before app launch and was interrupted; no app/test failure was produced.
