### PR TITLE
Add Firebase Analytics session ID binding

### DIFF
--- a/source/Firebase/Analytics/ApiDefinition.cs
+++ b/source/Firebase/Analytics/ApiDefinition.cs
@@ -6,6 +6,8 @@ using ObjCRuntime;
 
 namespace Firebase.Analytics
 {
+	delegate void SessionIdCompletionHandler (long sessionId, [NullAllowed] NSError error);
+
 	// @interface FIRAnalytics : NSObject
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRAnalytics")]
@@ -39,6 +41,11 @@ namespace Firebase.Analytics
 		[Static]
 		[Export ("setSessionTimeoutInterval:")]
 		void SetSessionTimeoutInterval (double sessionTimeoutInterval);
+
+		// + (void)sessionIDWithCompletion:(void (^)(int64_t sessionID, NSError *_Nullable error))completion;
+		[Static]
+		[Export ("sessionIDWithCompletion:")]
+		void SessionIdWithCompletion (SessionIdCompletionHandler completion);
 
 		// + (nullable NSString *)appInstanceID;
 		[Static]

--- a/source/Firebase/Analytics/ApiDefinition.cs
+++ b/source/Firebase/Analytics/ApiDefinition.cs
@@ -6,8 +6,6 @@ using ObjCRuntime;
 
 namespace Firebase.Analytics
 {
-	delegate void SessionIdCompletionHandler (long sessionId, [NullAllowed] NSError error);
-
 	// @interface FIRAnalytics : NSObject
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRAnalytics")]
@@ -45,7 +43,7 @@ namespace Firebase.Analytics
 		// + (void)sessionIDWithCompletion:(void (^)(int64_t sessionID, NSError *_Nullable error))completion;
 		[Static]
 		[Export ("sessionIDWithCompletion:")]
-		void SessionIdWithCompletion (SessionIdCompletionHandler completion);
+		void SessionIdWithCompletion (Action<long, NSError> completion);
 
 		// + (nullable NSString *)appInstanceID;
 		[Static]

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -1,5 +1,11 @@
 using System.Reflection;
 
+#if ENABLE_RUNTIME_DRIFT_CASE_ANALYTICS_SESSIONIDWITHCOMPLETION
+using Firebase.Analytics;
+using Foundation;
+using ObjCRuntime;
+#endif
+
 #if ENABLE_RUNTIME_DRIFT_CASE_DATABASE_SERVERVALUE_INCREMENT
 using Firebase.Database;
 using Foundation;
@@ -83,6 +89,100 @@ static class FirebaseRuntimeDriftCases
             .FirstOrDefault(attribute => string.Equals(attribute.Key, key, StringComparison.Ordinal))
             ?.Value;
     }
+
+#if ENABLE_RUNTIME_DRIFT_CASE_ANALYTICS_SESSIONIDWITHCOMPLETION
+    static async Task<string> VerifyAnalyticsSessionIdWithCompletionAsync()
+    {
+        const string selector = "sessionIDWithCompletion:";
+
+        var signature = typeof(Analytics).GetMethod(
+            nameof(Analytics.SessionIdWithCompletion),
+            BindingFlags.Static | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(SessionIdCompletionHandler) },
+            modifiers: null);
+        if (signature is null)
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{nameof(Analytics.SessionIdWithCompletion)}({typeof(SessionIdCompletionHandler).FullName})' was not found.");
+        }
+
+        Analytics.SetAnalyticsCollectionEnabled(true);
+        Analytics.SetConsent(new Dictionary<ConsentType, ConsentStatus>
+        {
+            [ConsentType.AnalyticsStorage] = ConsentStatus.Granted,
+            [ConsentType.AdStorage] = ConsentStatus.Denied,
+        });
+
+        var callbackInvoked = false;
+        long callbackSessionId = 0;
+        NSError? callbackError = null;
+        NSException? marshaledException = null;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+        var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledException ??= args.Exception;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            try
+            {
+                Analytics.SessionIdWithCompletion((sessionId, error) =>
+                {
+                    callbackInvoked = true;
+                    callbackSessionId = sessionId;
+                    callbackError = error;
+                    completionSource.TrySetResult(true);
+                });
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
+                    $"Completion delegate type: {typeof(SessionIdCompletionHandler).FullName}. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            var completedTask = await Task.WhenAny(completionSource.Task, Task.Delay(AsyncTimeout));
+            if (completedTask != completionSource.Task)
+            {
+                throw new TimeoutException(
+                    $"Selector '{selector}' did not invoke its completion callback within {AsyncTimeout.TotalSeconds} seconds.");
+            }
+
+            if (!callbackInvoked)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' completed without throwing, but the completion callback was never marked as invoked.");
+            }
+
+            if (marshaledException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
+                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            return
+                $"Selector '{selector}' invoked its completion callback without ObjC exception. " +
+                $"Completion delegate type: {typeof(SessionIdCompletionHandler).FullName}. " +
+                $"SessionId: {callbackSessionId}. " +
+                $"NSError: {callbackError?.LocalizedDescription ?? "<null>"}.";
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
+#endif
 
 #if ENABLE_RUNTIME_DRIFT_CASE_DATABASE_SERVERVALUE_INCREMENT
     static Task<string> VerifyDatabaseServerValueIncrementAsync()

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -99,12 +99,12 @@ static class FirebaseRuntimeDriftCases
             nameof(Analytics.SessionIdWithCompletion),
             BindingFlags.Static | BindingFlags.Public,
             binder: null,
-            types: new[] { typeof(SessionIdCompletionHandler) },
+            types: new[] { typeof(Action<long, NSError>) },
             modifiers: null);
         if (signature is null)
         {
             throw new InvalidOperationException(
-                $"Expected managed API '{nameof(Analytics.SessionIdWithCompletion)}({typeof(SessionIdCompletionHandler).FullName})' was not found.");
+                $"Expected managed API '{nameof(Analytics.SessionIdWithCompletion)}({typeof(Action<long, NSError>).FullName})' was not found.");
         }
 
         Analytics.SetAnalyticsCollectionEnabled(true);
@@ -144,7 +144,7 @@ static class FirebaseRuntimeDriftCases
             {
                 throw new InvalidOperationException(
                     $"Selector '{selector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
-                    $"Completion delegate type: {typeof(SessionIdCompletionHandler).FullName}. " +
+                    $"Completion delegate type: {typeof(Action<long, NSError>).FullName}. " +
                     $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
                     $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
                     $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
@@ -173,7 +173,7 @@ static class FirebaseRuntimeDriftCases
 
             return
                 $"Selector '{selector}' invoked its completion callback without ObjC exception. " +
-                $"Completion delegate type: {typeof(SessionIdCompletionHandler).FullName}. " +
+                $"Completion delegate type: {typeof(Action<long, NSError>).FullName}. " +
                 $"SessionId: {callbackSessionId}. " +
                 $"NSError: {callbackError?.LocalizedDescription ?? "<null>"}.";
         }

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -1,6 +1,12 @@
 {
   "cases": [
     {
+      "id": "analytics-sessionidwithcompletion",
+      "method": "VerifyAnalyticsSessionIdWithCompletionAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.Analytics",
+      "packages": []
+    },
+    {
       "id": "database-servervalue-increment",
       "method": "VerifyDatabaseServerValueIncrementAsync",
       "bindingPackage": "AdamE.Firebase.iOS.Database",

--- a/tools/e2e/run-firebase-foundation.sh
+++ b/tools/e2e/run-firebase-foundation.sh
@@ -124,7 +124,7 @@ method = case.get("method")
 binding_package = case.get("bindingPackage")
 packages = case.get("packages", [])
 
-if not method or not binding_package or not packages:
+if not method or not binding_package or packages is None:
     raise SystemExit(f"Runtime drift case '{case_id}' is missing required manifest fields.")
 
 symbol = "ENABLE_RUNTIME_DRIFT_CASE_" + re.sub(r"[^A-Za-z0-9]+", "_", case_id).strip("_").upper()
@@ -153,6 +153,7 @@ PY
   runtime_drift_details=("${(@f)$(<"$runtime_drift_info")}")
   runtime_drift_method="${runtime_drift_details[1]}"
   runtime_drift_binding_package="${runtime_drift_details[2]}"
+  required_packages+=("$runtime_drift_binding_package")
   for (( i = 3; i <= ${#runtime_drift_details[@]}; i++ )); do
     required_packages+=("${runtime_drift_details[$i]}")
   done


### PR DESCRIPTION
## Summary
- Add the missing Firebase Analytics binding for `+sessionIDWithCompletion:` from `FIRAnalytics.h`.
- Add a targeted local E2E case, `analytics-sessionidwithcompletion`, that calls the new managed API and verifies the call reaches native without binding-layer exceptions.
- Allow targeted E2E cases for packages already referenced by the base app to omit extra package references while still requiring the binding package in the local feed.

## Validation
- `dotnet pack source/Firebase/Analytics/Analytics.csproj --configuration Release --output output`
- `zsh -n tools/e2e/run-firebase-foundation.sh`
- `python3 -m json.tool tests/E2E/Firebase.Foundation/runtime-drift-cases.json >/dev/null`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case analytics-sessionidwithcompletion`

The targeted E2E case passed. The native callback returned `NSError: Analytics uninitialized`, which is acceptable here because the binding crossed into Firebase correctly without `ObjCRuntime.ObjCException`, selector failure, or marshaling failure.
