### PR TITLE
Fix Crashlytics stack frame address selector

### DIFF
--- a/source/Firebase/Crashlytics/ApiDefinition.cs
+++ b/source/Firebase/Crashlytics/ApiDefinition.cs
@@ -102,7 +102,7 @@ namespace Firebase.Crashlytics {
 
 		// + (instancetype)stackFrameWithAddress:(NSUInteger)address;
 		[Static]
-		[Export ("stackFrameWithAddress:address")]
+		[Export ("stackFrameWithAddress:")]
 		StackFrame Create (nuint address);
 
 		// +(instancetype _Nonnull)stackFrameWithSymbol:(NSString * _Nonnull)symbol file:(NSString * _Nonnull)file line:(NSInteger)line __attribute__((availability(swift, unavailable)));

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -42,6 +42,11 @@ using Foundation;
 using ObjCRuntime;
 #endif
 
+#if ENABLE_RUNTIME_DRIFT_CASE_CRASHLYTICS_STACKFRAMEWITHADDRESS
+using Firebase.Crashlytics;
+using ObjCRuntime;
+#endif
+
 namespace FirebaseFoundationE2E;
 
 static class FirebaseRuntimeDriftCases
@@ -673,6 +678,72 @@ static class FirebaseRuntimeDriftCases
                 $"Removed stale managed selector '{staleSelector}' and property 'EmulatorOrigin'. " +
                 $"Live selector '{liveSelector}' completed without ObjC exception after the binding fix. " +
                 $"Runtime host argument type: {typeof(string).FullName}. Runtime port argument type: {typeof(uint).FullName}.");
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
+#endif
+
+#if ENABLE_RUNTIME_DRIFT_CASE_CRASHLYTICS_STACKFRAMEWITHADDRESS
+    static Task<string> VerifyCrashlyticsStackFrameWithAddressAsync()
+    {
+        const string staleSelector = "stackFrameWithAddress:address";
+        const string liveSelector = "stackFrameWithAddress:";
+
+        var signature = typeof(StackFrame).GetMethod(
+            nameof(StackFrame.Create),
+            BindingFlags.Static | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(nuint) },
+            modifiers: null);
+        if (signature is null)
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{nameof(StackFrame.Create)}({typeof(nuint).FullName})' was not found.");
+        }
+
+        var marshaledExceptionCaptured = false;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledExceptionCaptured = true;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            try
+            {
+                using var stackFrame = StackFrame.Create((nuint)1);
+                if (stackFrame is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Selector '{liveSelector}' returned null after the binding fix. Runtime address argument type: {typeof(nuint).FullName}.");
+                }
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{liveSelector}' should not throw after the binding fix, but observed {ex.GetType().FullName}. " +
+                    $"Stale selector was '{staleSelector}'. " +
+                    $"Runtime address argument type: {typeof(nuint).FullName}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            if (marshaledExceptionCaptured)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{liveSelector}' completed, but Runtime.MarshalObjectiveCException captured an unexpected Objective-C exception. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            return Task.FromResult(
+                $"Corrected stale selector '{staleSelector}' to native selector '{liveSelector}'. " +
+                $"Runtime address argument type: {typeof(nuint).FullName}; StackFrame.Create returned without ObjC exception.");
         }
         finally
         {

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -71,6 +71,17 @@
           "version": "12.6.0"
         }
       ]
+    },
+    {
+      "id": "crashlytics-stackframewithaddress",
+      "method": "VerifyCrashlyticsStackFrameWithAddressAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.Crashlytics",
+      "packages": [
+        {
+          "id": "AdamE.Firebase.iOS.Crashlytics",
+          "version": "12.6.0"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix `Firebase.Crashlytics.StackFrame.Create(nuint)` to export the native `stackFrameWithAddress:` selector from `FIRStackFrame.h`.
- Add a targeted runtime-drift E2E case for `crashlytics-stackframewithaddress` that exercises `StackFrame.Create(nuint)` and fails on `ObjCRuntime.ObjCException` or unexpected Objective-C exception marshaling.

## Root Cause
`FIRStackFrame.h` exposes `+ (instancetype)stackFrameWithAddress:(NSUInteger)address;`, but the binding used the stale selector `stackFrameWithAddress:address`. That means the managed API could dispatch to a selector Firebase does not implement.

A pre-fix local proof run reached the `ObjCException` handling path for the stale selector. While formatting the marshaled `NSException`, the app aborted inside `Foundation_NSException_get_Name`, so the final regression test intentionally avoids dereferencing the marshaled `NSException` object and focuses on the binding-layer success/failure signal.

## Validation
- `dotnet pack source/Firebase/Crashlytics/Crashlytics.csproj --configuration Release --output output`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case crashlytics-stackframewithaddress`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug`

The targeted E2E case passed with: `StackFrame.Create returned without ObjC exception`.
