### PR TITLE
Add Firebase RemoteConfig realtime update bindings

### DIFF
--- a/source/Firebase/RemoteConfig/ApiDefinition.cs
+++ b/source/Firebase/RemoteConfig/ApiDefinition.cs
@@ -20,6 +20,19 @@ namespace Firebase.RemoteConfig
 	// typedef void (^_Nullable)(BOOL changed, NSError *_Nullable error);
 	delegate void RemoteConfigActivateCompletionHandler (bool changed, [NullAllowed] NSError error);
 
+	// typedef void (^FIRRemoteConfigUpdateCompletion)(FIRRemoteConfigUpdate * _Nullable, NSError * _Nullable);
+	delegate void RemoteConfigUpdateCompletionHandler ([NullAllowed] RemoteConfigUpdate configUpdate, [NullAllowed] NSError error);
+
+	// @interface FIRConfigUpdateListenerRegistration : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIRConfigUpdateListenerRegistration")]
+	interface ConfigUpdateListenerRegistration
+	{
+		// - (void)remove;
+		[Export ("remove")]
+		void Remove ();
+	}
+
 	// @interface FIRRemoteConfigValue : NSObject <NSCopying>
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRRemoteConfigValue")]
@@ -64,6 +77,16 @@ namespace Firebase.RemoteConfig
 		double FetchTimeout { get; set; }
 	}
 
+	// @interface FIRRemoteConfigUpdate : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIRRemoteConfigUpdate")]
+	interface RemoteConfigUpdate
+	{
+		// @property(nonatomic, readonly, nonnull) NSSet<NSString *> *updatedKeys;
+		[Export ("updatedKeys")]
+		NSSet<NSString> UpdatedKeys { get; }
+	}
+
 	// @interface FIRRemoteConfig : NSObject <NSFastEnumeration>
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRRemoteConfig")]
@@ -80,6 +103,14 @@ namespace Firebase.RemoteConfig
 		// extern NSString *const _Nonnull FIRRemoteConfigErrorDomain;
 		[Field ("FIRRemoteConfigErrorDomain", "__Internal")]
 		NSString ErrorDomain { get; }
+
+		// extern NSString *const _Nonnull FIRRemoteConfigUpdateErrorDomain;
+		[Field ("FIRRemoteConfigUpdateErrorDomain", "__Internal")]
+		NSString UpdateErrorDomain { get; }
+
+		// extern NSString *const _Nonnull FIRRemoteConfigCustomSignalsErrorDomain;
+		[Field ("FIRRemoteConfigCustomSignalsErrorDomain", "__Internal")]
+		NSString CustomSignalsErrorDomain { get; }
 
 		// @property(nonatomic, readonly, strong, nullable) NSDate *lastFetchTime;
 		[NullAllowed]
@@ -167,5 +198,14 @@ namespace Firebase.RemoteConfig
 		[return: NullAllowed]
 		[Export ("defaultValueForKey:")]
 		RemoteConfigValue GetDefaultValue ([NullAllowed] string key);
+
+		// - (FIRConfigUpdateListenerRegistration *_Nonnull)addOnConfigUpdateListener:(FIRRemoteConfigUpdateCompletion _Nonnull)listener;
+		[Export ("addOnConfigUpdateListener:")]
+		ConfigUpdateListenerRegistration AddOnConfigUpdateListener (RemoteConfigUpdateCompletionHandler listener);
+
+		// - (void)setCustomSignals:(nonnull NSDictionary<NSString *, NSObject *> *)customSignals withCompletion:(void (^_Nullable)(NSError *_Nullable error))completionHandler;
+		[Async]
+		[Export ("setCustomSignals:withCompletion:")]
+		void SetCustomSignals (NSDictionary<NSString, NSObject> customSignals, [NullAllowed] Action<NSError> completionHandler);
 	}
 }

--- a/source/Firebase/RemoteConfig/Enums.cs
+++ b/source/Firebase/RemoteConfig/Enums.cs
@@ -29,6 +29,23 @@ namespace Firebase.RemoteConfig
 	}
 
 	[Native]
+	public enum RemoteConfigUpdateError : long
+	{
+		StreamError = 8001,
+		NotFetched = 8002,
+		MessageInvalid = 8003,
+		Unavailable = 8004
+	}
+
+	[Native]
+	public enum RemoteConfigCustomSignalsError : long
+	{
+		Unknown = 8101,
+		InvalidValueType = 8102,
+		LimitExceeded = 8103
+	}
+
+	[Native]
 	public enum RemoteConfigSource : long
 	{
 		Remote,

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -12,6 +12,12 @@ using Foundation;
 using ObjCRuntime;
 #endif
 
+#if ENABLE_RUNTIME_DRIFT_CASE_REMOTECONFIG_REALTIME_CUSTOMSIGNALS
+using Firebase.RemoteConfig;
+using Foundation;
+using ObjCRuntime;
+#endif
+
 #if ENABLE_RUNTIME_DRIFT_CASE_DATABASE_SERVERVALUE_INCREMENT
 using Firebase.Database;
 using Foundation;
@@ -287,6 +293,161 @@ static class FirebaseRuntimeDriftCases
             return Task.FromResult(
                 "Analytics on-device conversion selectors completed without ObjC exception. " +
                 $"String argument type: {typeof(string).FullName}. Hashed argument type: {typeof(NSData).FullName}.");
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
+#endif
+
+#if ENABLE_RUNTIME_DRIFT_CASE_REMOTECONFIG_REALTIME_CUSTOMSIGNALS
+    static async Task<string> VerifyRemoteConfigRealtimeCustomSignalsAsync()
+    {
+        const string listenerSelector = "addOnConfigUpdateListener:";
+        const string customSignalsSelector = "setCustomSignals:withCompletion:";
+
+        var listenerSignature = typeof(RemoteConfig).GetMethod(
+            nameof(RemoteConfig.AddOnConfigUpdateListener),
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(RemoteConfigUpdateCompletionHandler) },
+            modifiers: null);
+        if (listenerSignature is null)
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{nameof(RemoteConfig.AddOnConfigUpdateListener)}({typeof(RemoteConfigUpdateCompletionHandler).FullName})' was not found.");
+        }
+
+        if (listenerSignature.ReturnType != typeof(ConfigUpdateListenerRegistration))
+        {
+            throw new InvalidOperationException(
+                $"Managed signature regression: expected '{nameof(RemoteConfig.AddOnConfigUpdateListener)}' to return '{typeof(ConfigUpdateListenerRegistration).FullName}', observed '{listenerSignature.ReturnType.FullName}'.");
+        }
+
+        var customSignalsSignature = typeof(RemoteConfig).GetMethod(
+            nameof(RemoteConfig.SetCustomSignals),
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(NSDictionary<NSString, NSObject>), typeof(Action<NSError>) },
+            modifiers: null);
+        if (customSignalsSignature is null)
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{nameof(RemoteConfig.SetCustomSignals)}({typeof(NSDictionary<NSString, NSObject>).FullName}, {typeof(Action<NSError>).FullName})' was not found.");
+        }
+
+        var remoteConfig = RemoteConfig.SharedInstance;
+        if (remoteConfig is null)
+        {
+            throw new InvalidOperationException("Firebase.RemoteConfig.RemoteConfig.SharedInstance returned null after App.Configure().");
+        }
+
+        if (!remoteConfig.RespondsToSelector(new Selector(listenerSelector)))
+        {
+            throw new InvalidOperationException($"Native FIRRemoteConfig does not respond to expected selector '{listenerSelector}'.");
+        }
+
+        if (!remoteConfig.RespondsToSelector(new Selector(customSignalsSelector)))
+        {
+            throw new InvalidOperationException($"Native FIRRemoteConfig does not respond to expected selector '{customSignalsSelector}'.");
+        }
+
+        var listenerInvoked = false;
+        var listenerUpdateWasNull = false;
+        NSError? listenerError = null;
+        var customSignalsCompletionInvoked = false;
+        NSError? customSignalsCompletionError = null;
+        NSException? marshaledException = null;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+        var customSignalsCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledException ??= args.Exception;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            using var signalKey = new NSString("codex_signal");
+            using var signalValue = new NSString("enabled");
+            using var customSignals = NSDictionary<NSString, NSObject>.FromObjectsAndKeys(
+                new NSObject[] { signalValue },
+                new[] { signalKey },
+                1);
+
+            ConfigUpdateListenerRegistration registration;
+            try
+            {
+                registration = remoteConfig.AddOnConfigUpdateListener((configUpdate, error) =>
+                {
+                    listenerInvoked = true;
+                    listenerUpdateWasNull = configUpdate is null;
+                    listenerError = error;
+                });
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{listenerSelector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
+                    $"Listener delegate type: {typeof(RemoteConfigUpdateCompletionHandler).FullName}. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            using (registration)
+            {
+                if (registration is null)
+                {
+                    throw new InvalidOperationException($"Selector '{listenerSelector}' returned null registration.");
+                }
+
+                registration.Remove();
+            }
+
+            try
+            {
+                remoteConfig.SetCustomSignals(customSignals, error =>
+                {
+                    customSignalsCompletionInvoked = true;
+                    customSignalsCompletionError = error;
+                    customSignalsCompletionSource.TrySetResult(true);
+                });
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{customSignalsSelector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
+                    $"Signals dictionary type: {customSignals.GetType().FullName}. Completion delegate type: {typeof(Action<NSError>).FullName}. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            var completedTask = await Task.WhenAny(customSignalsCompletionSource.Task, Task.Delay(AsyncTimeout));
+            if (marshaledException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"RemoteConfig missing-surface selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
+                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            return
+                $"Selectors '{listenerSelector}' and '{customSignalsSelector}' completed without ObjC exception after the missing bindings were added. " +
+                $"Listener delegate type: {typeof(RemoteConfigUpdateCompletionHandler).FullName}. " +
+                $"Registration type: {typeof(ConfigUpdateListenerRegistration).FullName}. " +
+                $"Update type: {typeof(RemoteConfigUpdate).FullName}. " +
+                $"Signals dictionary type: {customSignals.GetType().FullName}. " +
+                $"Custom signals callback observed: {completedTask == customSignalsCompletionSource.Task}. " +
+                $"Custom signals callback invoked: {customSignalsCompletionInvoked}. " +
+                $"Custom signals NSError: {FormatDetail(customSignalsCompletionError?.LocalizedDescription)}. " +
+                $"Listener invoked: {listenerInvoked}. Listener update was null: {listenerUpdateWasNull}. " +
+                $"Listener NSError: {FormatDetail(listenerError?.LocalizedDescription)}.";
         }
         finally
         {

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -437,6 +437,13 @@ static class FirebaseRuntimeDriftCases
                     $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
             }
 
+            if (completedTask != customSignalsCompletionSource.Task)
+            {
+                throw new TimeoutException(
+                    $"Selector '{customSignalsSelector}' did not invoke its completion callback within {AsyncTimeout.TotalSeconds} seconds. " +
+                    $"Signals dictionary type: {customSignals.GetType().FullName}. Completion delegate type: {typeof(Action<NSError>).FullName}.");
+            }
+
             return
                 $"Selectors '{listenerSelector}' and '{customSignalsSelector}' completed without ObjC exception after the missing bindings were added. " +
                 $"Listener delegate type: {typeof(RemoteConfigUpdateCompletionHandler).FullName}. " +

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -13,6 +13,21 @@
       "packages": []
     },
     {
+      "id": "remoteconfig-realtime-customsignals",
+      "method": "VerifyRemoteConfigRealtimeCustomSignalsAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.RemoteConfig",
+      "packages": [
+        {
+          "id": "AdamE.Firebase.iOS.RemoteConfig",
+          "version": "12.6.0"
+        },
+        {
+          "id": "AdamE.Firebase.iOS.ABTesting",
+          "version": "12.6.0"
+        }
+      ]
+    },
+    {
       "id": "database-servervalue-increment",
       "method": "VerifyDatabaseServerValueIncrementAsync",
       "bindingPackage": "AdamE.Firebase.iOS.Database",


### PR DESCRIPTION
## Summary
- Add header-backed Firebase RemoteConfig real-time update bindings: `ConfigUpdateListenerRegistration`, `RemoteConfigUpdate`, and `AddOnConfigUpdateListener`.
- Add RemoteConfig custom-signals binding and related update/custom-signals error enums and domains.
- Add a targeted E2E runtime-drift case, `remoteconfig-realtime-customsignals`, that verifies the managed APIs exist and the selectors cross into native without ObjC/marshaling exceptions.

## Validation
- `dotnet pack source/Firebase/RemoteConfig/RemoteConfig.csproj --configuration Release --output output`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case remoteconfig-realtime-customsignals`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug`

## Notes
- This is a missing-surface fix rather than a stale-selector runtime-crash fix; the E2E case proves native selector exercise and completion callback behavior after adding the bindings.
- Local simulator first-boot/dyld-cache warm-up delayed the run, but the final targeted and default E2E runs passed on the warmed iOS simulator.