### PR TITLE
Add Firestore named database bindings

### DIFF
--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -647,6 +647,16 @@ namespace Firebase.CloudFirestore
 		[Export ("firestoreForApp:")]
 		Firestore Create (Firebase.Core.App app);
 
+		// +(instancetype _Nonnull)firestoreForApp:(FIRApp * _Nonnull)app database:(NSString * _Nonnull)database;
+		[Static]
+		[Export ("firestoreForApp:database:")]
+		Firestore Create (Firebase.Core.App app, string database);
+
+		// +(instancetype _Nonnull)firestoreForDatabase:(NSString * _Nonnull)database;
+		[Static]
+		[Export ("firestoreForDatabase:")]
+		Firestore Create (string database);
+
 		// @property (copy, nonatomic) FIRFirestoreSettings * _Nonnull settings;
 		[Export ("settings", ArgumentSemantic.Copy)]
 		FirestoreSettings Settings { get; set; }

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -72,6 +72,12 @@ using Foundation;
 using ObjCRuntime;
 #endif
 
+#if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFIRESTORE_NAMED_DATABASE
+using Firebase.CloudFirestore;
+using Foundation;
+using ObjCRuntime;
+#endif
+
 #if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFUNCTIONS_USEFUNCTIONSEMULATORORIGIN
 using Firebase.CloudFunctions;
 using Foundation;
@@ -1873,6 +1879,119 @@ static class FirebaseRuntimeDriftCases
         }
     }
 
+#endif
+
+#if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFIRESTORE_NAMED_DATABASE
+    static Task<string> VerifyCloudFirestoreNamedDatabaseAsync()
+    {
+        const string firestoreForDatabaseSelector = "firestoreForDatabase:";
+        const string firestoreForAppDatabaseSelector = "firestoreForApp:database:";
+        const string databaseId = "(default)";
+
+        var databaseSignature = typeof(Firestore).GetMethod(
+            nameof(Firestore.Create),
+            BindingFlags.Static | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(string) },
+            modifiers: null);
+        if (databaseSignature?.ReturnType != typeof(Firestore))
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{typeof(Firestore).FullName}.{nameof(Firestore.Create)}({typeof(string).FullName})' " +
+                $"to return '{typeof(Firestore).FullName}' for selector '{firestoreForDatabaseSelector}', " +
+                $"observed '{databaseSignature?.ReturnType.FullName ?? "<missing>"}'.");
+        }
+
+        var appDatabaseSignature = typeof(Firestore).GetMethod(
+            nameof(Firestore.Create),
+            BindingFlags.Static | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(Firebase.Core.App), typeof(string) },
+            modifiers: null);
+        if (appDatabaseSignature?.ReturnType != typeof(Firestore))
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{typeof(Firestore).FullName}.{nameof(Firestore.Create)}({typeof(Firebase.Core.App).FullName}, {typeof(string).FullName})' " +
+                $"to return '{typeof(Firestore).FullName}' for selector '{firestoreForAppDatabaseSelector}', " +
+                $"observed '{appDatabaseSignature?.ReturnType.FullName ?? "<missing>"}'.");
+        }
+
+        var defaultApp = Firebase.Core.App.DefaultInstance
+            ?? throw new InvalidOperationException("Firebase.Core.App.DefaultInstance returned null after App.Configure().");
+        NSException? marshaledException = null;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledException ??= args.Exception;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            Firestore? defaultNamedDatabase = null;
+            Firestore? appNamedDatabase = null;
+            try
+            {
+                defaultNamedDatabase = Firestore.Create(databaseId);
+                appNamedDatabase = Firestore.Create(defaultApp, databaseId);
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Firestore named-database selectors should not throw after the missing bindings are added, but observed {ex.GetType().FullName}. " +
+                    $"Selectors exercised: '{firestoreForDatabaseSelector}', '{firestoreForAppDatabaseSelector}'. " +
+                    $"Database id: {databaseId}. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            if (defaultNamedDatabase is null)
+            {
+                throw new InvalidOperationException($"Selector '{firestoreForDatabaseSelector}' returned null.");
+            }
+
+            if (appNamedDatabase is null)
+            {
+                throw new InvalidOperationException($"Selector '{firestoreForAppDatabaseSelector}' returned null.");
+            }
+
+            var defaultCollection = defaultNamedDatabase.GetCollection($"codex-named-database-default-{Guid.NewGuid():N}");
+            if (defaultCollection is null)
+            {
+                throw new InvalidOperationException(
+                    $"Firestore instance from selector '{firestoreForDatabaseSelector}' could not create a collection reference.");
+            }
+
+            var appCollection = appNamedDatabase.GetCollection($"codex-named-database-app-{Guid.NewGuid():N}");
+            if (appCollection is null)
+            {
+                throw new InvalidOperationException(
+                    $"Firestore instance from selector '{firestoreForAppDatabaseSelector}' could not create a collection reference.");
+            }
+
+            if (marshaledException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Firestore named-database selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
+                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            return Task.FromResult(
+                $"Firestore named-database factory APIs crossed the native selector boundary. " +
+                $"Database id: {databaseId}. " +
+                $"Default-app selector returned: {defaultNamedDatabase.GetType().FullName}. " +
+                $"Explicit-app selector returned: {appNamedDatabase.GetType().FullName}. " +
+                $"Collection references: {defaultCollection.Path}, {appCollection.Path}.");
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
 #endif
 
 #if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFUNCTIONS_USEFUNCTIONSEMULATORORIGIN

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -127,6 +127,17 @@
       ]
     },
     {
+      "id": "cloudfirestore-named-database",
+      "method": "VerifyCloudFirestoreNamedDatabaseAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.CloudFirestore",
+      "packages": [
+        {
+          "id": "AdamE.Firebase.iOS.CloudFirestore",
+          "version": "12.6.0"
+        }
+      ]
+    },
+    {
       "id": "cloudfunctions-usefunctionsemulatororigin",
       "method": "VerifyCloudFunctionsUseFunctionsEmulatorOriginAsync",
       "bindingPackage": "AdamE.Firebase.iOS.CloudFunctions",


### PR DESCRIPTION
## Summary

Adds the Firestore named-database factory APIs that are present in Firebase 12.6 but missing from the current bindings:

- `Firestore.Create(string database)` for native selector `firestoreForDatabase:`
- `Firestore.Create(App app, string database)` for native selector `firestoreForApp:database:`

This also adds a targeted runtime-drift E2E case, `cloudfirestore-named-database`, which exercises both selectors with database id `(default)`, asserts non-null returned `Firestore` instances, and creates collection references from both returned objects to verify the instances are usable.

## Scope

This PR is intentionally Firestore-focused. It does not include audit tooling, backlog cleanup, CI changes, or unrelated Firestore drift work.

## Verification

- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.CloudFirestore"`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case cloudfirestore-named-database`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug`
- `git diff --check`

Both E2E runs passed. The targeted case reported that both Firestore named-database factory APIs crossed the native selector boundary and produced usable collection references.