### PR TITLE
Add Firestore cache settings bindings

### DIFF
--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -665,6 +665,11 @@ namespace Firebase.CloudFirestore
 		[Export ("app", ArgumentSemantic.Strong)]
 		Firebase.Core.App App { get; }
 
+		// @property (nonatomic, readonly, nullable) FIRPersistentCacheIndexManager * _Nullable persistentCacheIndexManager;
+		[NullAllowed]
+		[Export ("persistentCacheIndexManager")]
+		PersistentCacheIndexManager PersistentCacheIndexManager { get; }
+
 		// -(FIRCollectionReference * _Nonnull)collectionWithPath:(NSString * _Nonnull)collectionPath;
 		[Export ("collectionWithPath:")]
 		CollectionReference GetCollection (string collectionPath);
@@ -814,6 +819,61 @@ namespace Firebase.CloudFirestore
 		// @property (assign, nonatomic) int64_t cacheSizeBytes;
 		[Export ("cacheSizeBytes")]
 		long CacheSizeBytes { get; set; }
+
+		// @property(nonatomic, strong) id<FIRLocalCacheSettings, NSObject> _Nonnull cacheSettings;
+		[Export ("cacheSettings", ArgumentSemantic.Strong)]
+		NSObject CacheSettings { get; set; }
+	}
+
+	// @interface FIRPersistentCacheSettings : NSObject <NSCopying, FIRLocalCacheSettings>
+	[BaseType (typeof (NSObject), Name = "FIRPersistentCacheSettings")]
+	interface PersistentCacheSettings : INSCopying
+	{
+		// - (instancetype _Nonnull)initWithSizeBytes:(NSNumber * _Nonnull)size;
+		[Export ("initWithSizeBytes:")]
+		NativeHandle Constructor (NSNumber size);
+	}
+
+	// @interface FIRMemoryEagerGCSettings : NSObject <NSCopying, FIRMemoryGarbageCollectorSettings>
+	[BaseType (typeof (NSObject), Name = "FIRMemoryEagerGCSettings")]
+	interface MemoryEagerGCSettings : INSCopying
+	{
+	}
+
+	// @interface FIRMemoryLRUGCSettings : NSObject <NSCopying, FIRMemoryGarbageCollectorSettings>
+	[BaseType (typeof (NSObject), Name = "FIRMemoryLRUGCSettings")]
+	interface MemoryLRUGCSettings : INSCopying
+	{
+		// - (instancetype _Nonnull)initWithSizeBytes:(NSNumber * _Nonnull)size;
+		[Export ("initWithSizeBytes:")]
+		NativeHandle Constructor (NSNumber size);
+	}
+
+	// @interface FIRMemoryCacheSettings : NSObject <NSCopying, FIRLocalCacheSettings>
+	[BaseType (typeof (NSObject), Name = "FIRMemoryCacheSettings")]
+	interface MemoryCacheSettings : INSCopying
+	{
+		// - (instancetype _Nonnull)initWithGarbageCollectorSettings:(id<FIRMemoryGarbageCollectorSettings, NSObject> _Nonnull)settings;
+		[Export ("initWithGarbageCollectorSettings:")]
+		NativeHandle Constructor (NSObject settings);
+	}
+
+	// @interface FIRPersistentCacheIndexManager : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIRPersistentCacheIndexManager")]
+	interface PersistentCacheIndexManager
+	{
+		// - (void)enableIndexAutoCreation;
+		[Export ("enableIndexAutoCreation")]
+		void EnableIndexAutoCreation ();
+
+		// - (void)disableIndexAutoCreation;
+		[Export ("disableIndexAutoCreation")]
+		void DisableIndexAutoCreation ();
+
+		// - (void)deleteAllIndexes;
+		[Export ("deleteAllIndexes")]
+		void DeleteAllIndexes ();
 	}
 
 	// @interface FIRGeoPoint : NSObject <NSCopying>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -78,6 +78,12 @@ using Foundation;
 using ObjCRuntime;
 #endif
 
+#if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFIRESTORE_CACHE_SETTINGS
+using Firebase.CloudFirestore;
+using Foundation;
+using ObjCRuntime;
+#endif
+
 #if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFUNCTIONS_USEFUNCTIONSEMULATORORIGIN
 using Firebase.CloudFunctions;
 using Foundation;
@@ -1990,6 +1996,217 @@ static class FirebaseRuntimeDriftCases
         finally
         {
             Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
+#endif
+
+#if ENABLE_RUNTIME_DRIFT_CASE_CLOUDFIRESTORE_CACHE_SETTINGS
+    static Task<string> VerifyCloudFirestoreCacheSettingsAsync()
+    {
+        const string cacheSettingsSelector = "cacheSettings";
+        const string setCacheSettingsSelector = "setCacheSettings:";
+        const string persistentCacheIndexManagerSelector = "persistentCacheIndexManager";
+        const string enableIndexAutoCreationSelector = "enableIndexAutoCreation";
+        const string disableIndexAutoCreationSelector = "disableIndexAutoCreation";
+        const string deleteAllIndexesSelector = "deleteAllIndexes";
+
+        var cacheSettingsProperty = typeof(FirestoreSettings).GetProperty(
+            nameof(FirestoreSettings.CacheSettings),
+            BindingFlags.Instance | BindingFlags.Public);
+        if (cacheSettingsProperty?.PropertyType != typeof(NSObject))
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{typeof(FirestoreSettings).FullName}.{nameof(FirestoreSettings.CacheSettings)}' " +
+                $"to return '{typeof(NSObject).FullName}' for selector '{cacheSettingsSelector}', " +
+                $"observed '{cacheSettingsProperty?.PropertyType.FullName ?? "<missing>"}'.");
+        }
+
+        var persistentCacheIndexManagerProperty = typeof(Firestore).GetProperty(
+            nameof(Firestore.PersistentCacheIndexManager),
+            BindingFlags.Instance | BindingFlags.Public);
+        if (persistentCacheIndexManagerProperty?.PropertyType != typeof(PersistentCacheIndexManager))
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{typeof(Firestore).FullName}.{nameof(Firestore.PersistentCacheIndexManager)}' " +
+                $"to return '{typeof(PersistentCacheIndexManager).FullName}' for selector '{persistentCacheIndexManagerSelector}', " +
+                $"observed '{persistentCacheIndexManagerProperty?.PropertyType.FullName ?? "<missing>"}'.");
+        }
+
+        RequireConstructor(typeof(PersistentCacheSettings), Type.EmptyTypes, "init");
+        RequireConstructor(typeof(PersistentCacheSettings), new[] { typeof(NSNumber) }, "initWithSizeBytes:");
+        RequireConstructor(typeof(MemoryEagerGCSettings), Type.EmptyTypes, "init");
+        RequireConstructor(typeof(MemoryLRUGCSettings), Type.EmptyTypes, "init");
+        RequireConstructor(typeof(MemoryLRUGCSettings), new[] { typeof(NSNumber) }, "initWithSizeBytes:");
+        RequireConstructor(typeof(MemoryCacheSettings), Type.EmptyTypes, "init");
+        RequireConstructor(typeof(MemoryCacheSettings), new[] { typeof(NSObject) }, "initWithGarbageCollectorSettings:");
+        RequireVoidMethod(typeof(PersistentCacheIndexManager), nameof(PersistentCacheIndexManager.EnableIndexAutoCreation), enableIndexAutoCreationSelector);
+        RequireVoidMethod(typeof(PersistentCacheIndexManager), nameof(PersistentCacheIndexManager.DisableIndexAutoCreation), disableIndexAutoCreationSelector);
+        RequireVoidMethod(typeof(PersistentCacheIndexManager), nameof(PersistentCacheIndexManager.DeleteAllIndexes), deleteAllIndexesSelector);
+
+        var firestore = Firestore.SharedInstance;
+        if (firestore is null)
+        {
+            throw new InvalidOperationException("Firebase.CloudFirestore.Firestore.SharedInstance returned null after App.Configure().");
+        }
+
+        if (!firestore.RespondsToSelector(new Selector(persistentCacheIndexManagerSelector)))
+        {
+            throw new InvalidOperationException(
+                $"Native FIRFirestore does not respond to expected selector '{persistentCacheIndexManagerSelector}'.");
+        }
+
+        NSException? marshaledException = null;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledException ??= args.Exception;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            string cacheSettingsRuntimeTypes;
+            string managerRuntimeType;
+            try
+            {
+                using var sizeBytes = NSNumber.FromInt64(100 * 1024 * 1024);
+                using var settings = new FirestoreSettings();
+
+                if (!settings.RespondsToSelector(new Selector(cacheSettingsSelector)))
+                {
+                    throw new InvalidOperationException(
+                        $"Native FIRFirestoreSettings does not respond to expected selector '{cacheSettingsSelector}'.");
+                }
+
+                if (!settings.RespondsToSelector(new Selector(setCacheSettingsSelector)))
+                {
+                    throw new InvalidOperationException(
+                        $"Native FIRFirestoreSettings does not respond to expected selector '{setCacheSettingsSelector}'.");
+                }
+
+                using var persistentDefault = new PersistentCacheSettings();
+                using var persistentSized = new PersistentCacheSettings(sizeBytes);
+                using var eagerGc = new MemoryEagerGCSettings();
+                using var lruGcDefault = new MemoryLRUGCSettings();
+                using var lruGcSized = new MemoryLRUGCSettings(sizeBytes);
+                using var memoryDefault = new MemoryCacheSettings();
+                using var memoryEager = new MemoryCacheSettings(eagerGc);
+                using var memoryLruDefault = new MemoryCacheSettings(lruGcDefault);
+                using var memoryLru = new MemoryCacheSettings(lruGcSized);
+                var observedCacheSettingsTypes = new List<string>();
+
+                settings.CacheSettings = persistentDefault;
+                observedCacheSettingsTypes.Add(RequireCacheSettings(settings, nameof(PersistentCacheSettings)));
+
+                settings.CacheSettings = persistentSized;
+                observedCacheSettingsTypes.Add(RequireCacheSettings(settings, nameof(PersistentCacheSettings)));
+
+                settings.CacheSettings = memoryDefault;
+                observedCacheSettingsTypes.Add(RequireCacheSettings(settings, nameof(MemoryCacheSettings)));
+
+                settings.CacheSettings = memoryEager;
+                observedCacheSettingsTypes.Add(RequireCacheSettings(settings, nameof(MemoryCacheSettings)));
+
+                settings.CacheSettings = memoryLruDefault;
+                observedCacheSettingsTypes.Add(RequireCacheSettings(settings, nameof(MemoryCacheSettings)));
+
+                settings.CacheSettings = memoryLru;
+                observedCacheSettingsTypes.Add(RequireCacheSettings(settings, nameof(MemoryCacheSettings)));
+                cacheSettingsRuntimeTypes = string.Join(", ", observedCacheSettingsTypes);
+
+                var manager = firestore.PersistentCacheIndexManager;
+                if (manager is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Selector '{persistentCacheIndexManagerSelector}' returned null for the default persistent Firestore cache.");
+                }
+
+                managerRuntimeType = manager.GetType().FullName ?? "<unknown>";
+
+                if (!manager.RespondsToSelector(new Selector(enableIndexAutoCreationSelector)))
+                {
+                    throw new InvalidOperationException(
+                        $"Native FIRPersistentCacheIndexManager does not respond to expected selector '{enableIndexAutoCreationSelector}'.");
+                }
+
+                if (!manager.RespondsToSelector(new Selector(disableIndexAutoCreationSelector)))
+                {
+                    throw new InvalidOperationException(
+                        $"Native FIRPersistentCacheIndexManager does not respond to expected selector '{disableIndexAutoCreationSelector}'.");
+                }
+
+                if (!manager.RespondsToSelector(new Selector(deleteAllIndexesSelector)))
+                {
+                    throw new InvalidOperationException(
+                        $"Native FIRPersistentCacheIndexManager does not respond to expected selector '{deleteAllIndexesSelector}'.");
+                }
+
+                manager.EnableIndexAutoCreation();
+                manager.DisableIndexAutoCreation();
+                manager.DeleteAllIndexes();
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Firestore cache settings selectors should not throw after the missing bindings are added, but observed {ex.GetType().FullName}. " +
+                    $"Selectors exercised: '{cacheSettingsSelector}', '{setCacheSettingsSelector}', '{persistentCacheIndexManagerSelector}', " +
+                    $"'{enableIndexAutoCreationSelector}', '{disableIndexAutoCreationSelector}', '{deleteAllIndexesSelector}', " +
+                    $"initWithSizeBytes:, initWithGarbageCollectorSettings:. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            if (marshaledException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Firestore cache settings selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
+                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            return Task.FromResult(
+                $"Firestore cache settings and persistent cache index manager APIs crossed the native selector boundary. " +
+                $"Observed cache settings runtime types: {cacheSettingsRuntimeTypes}. " +
+                $"Index manager runtime type: {managerRuntimeType}. " +
+                $"Selectors exercised: '{cacheSettingsSelector}', '{setCacheSettingsSelector}', '{persistentCacheIndexManagerSelector}', " +
+                $"'{enableIndexAutoCreationSelector}', '{disableIndexAutoCreationSelector}', '{deleteAllIndexesSelector}'.");
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+
+        static void RequireConstructor(Type type, Type[] parameterTypes, string selector)
+        {
+            var constructor = type.GetConstructor(parameterTypes);
+            if (constructor is null)
+            {
+                throw new InvalidOperationException(
+                    $"Expected managed constructor '{type.FullName}({string.Join(", ", parameterTypes.Select(parameterType => parameterType.FullName))})' " +
+                    $"was not found for selector '{selector}'.");
+            }
+        }
+
+        static void RequireVoidMethod(Type type, string methodName, string selector)
+        {
+            var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, binder: null, Type.EmptyTypes, modifiers: null);
+            if (method?.ReturnType != typeof(void))
+            {
+                throw new InvalidOperationException(
+                    $"Expected managed API '{type.FullName}.{methodName}()' to return void for selector '{selector}', " +
+                    $"observed '{method?.ReturnType.FullName ?? "<missing>"}'.");
+            }
+        }
+
+        static string RequireCacheSettings(FirestoreSettings settings, string assignedRuntimeTypeName)
+        {
+            var cacheSettings = settings.CacheSettings
+                ?? throw new InvalidOperationException($"FirestoreSettings.CacheSettings returned null after assigning {assignedRuntimeTypeName}.");
+
+            return cacheSettings.GetType().FullName ?? assignedRuntimeTypeName;
         }
     }
 #endif

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -138,6 +138,17 @@
       ]
     },
     {
+      "id": "cloudfirestore-cache-settings",
+      "method": "VerifyCloudFirestoreCacheSettingsAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.CloudFirestore",
+      "packages": [
+        {
+          "id": "AdamE.Firebase.iOS.CloudFirestore",
+          "version": "12.6.0"
+        }
+      ]
+    },
+    {
       "id": "cloudfunctions-usefunctionsemulatororigin",
       "method": "VerifyCloudFunctionsUseFunctionsEmulatorOriginAsync",
       "bindingPackage": "AdamE.Firebase.iOS.CloudFunctions",


### PR DESCRIPTION
## Summary

- Adds the missing Firestore cache settings bindings for `FIRPersistentCacheSettings`, `FIRMemoryEagerGCSettings`, `FIRMemoryLRUGCSettings`, `FIRMemoryCacheSettings`, and `FIRPersistentCacheIndexManager`.
- Adds `FirestoreSettings.CacheSettings` and `Firestore.PersistentCacheIndexManager` so the cache configuration/index-manager API surface is reachable from C#.
- Adds the targeted local E2E runtime drift case `cloudfirestore-cache-settings`.

## Notes

The native cache settings slots are marker-protocol typed (`id<..., NSObject>`). This PR binds those slots as `NSObject` so the concrete native cache settings objects can be passed through directly without adding binding-side wrapper logic. The E2E case exercises the relevant selectors and verifies no Objective-C marshal exception is raised.

Out of scope for this slice: deprecated index-configuration APIs, transaction options, broader audit tooling, and unrelated backlog cleanup.

## Validation

- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.CloudFirestore"`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case cloudfirestore-cache-settings`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug`
- `git diff --check`

targeted E2E result: `RuntimeDrift:cloudfirestore-cache-settings` passed and exercised `cacheSettings`, `setCacheSettings:`, `persistentCacheIndexManager`, `enableIndexAutoCreation`, `disableIndexAutoCreation`, and `deleteAllIndexes`.