### PR TITLE
Add AppCheck limited-use token bindings

### DIFF
--- a/source/Firebase/AppCheck/ApiDefinition.cs
+++ b/source/Firebase/AppCheck/ApiDefinition.cs
@@ -40,6 +40,10 @@ namespace Firebase.AppCheck {
 		[Export ("tokenForcingRefresh:completion:")]
 		void TokenForcingRefresh (bool forcingRefresh, TokenCompletionHandler handler);
 
+		// -(void)limitedUseTokenWithCompletion:(void (^ _Nonnull)(FIRAppCheckToken * _Nullable, NSError * _Nullable))handler;
+		[Export ("limitedUseTokenWithCompletion:")]
+		void LimitedUseTokenWithCompletion (TokenCompletionHandler handler);
+
 		// +(void)setAppCheckProviderFactory:(id<FIRAppCheckProviderFactory> _Nullable)factory;
 		[Static]
 		[Export ("setAppCheckProviderFactory:")]
@@ -61,6 +65,10 @@ namespace Firebase.AppCheck {
 		[Abstract]
 		[Export ("getTokenWithCompletion:")]
 		void GetTokenWithCompletion (TokenCompletionHandler handler);
+
+		// @optional -(void)getLimitedUseTokenWithCompletion:(void (^ _Nonnull)(FIRAppCheckToken * _Nullable, NSError * _Nullable))handler __attribute__((swift_name("getLimitedUseToken(completion:)")));
+		[Export ("getLimitedUseTokenWithCompletion:")]
+		void GetLimitedUseTokenWithCompletion (TokenCompletionHandler handler);
 	}
 
 	// @protocol FIRAppCheckProviderFactory <NSObject>
@@ -108,6 +116,10 @@ namespace Firebase.AppCheck {
 		// -(NSString * _Nonnull)currentDebugToken;
 		[Export ("currentDebugToken")]
 		string CurrentDebugToken { get; }
+
+		// -(void)getLimitedUseTokenWithCompletion:(void (^ _Nonnull)(FIRAppCheckToken * _Nullable, NSError * _Nullable))handler __attribute__((swift_name("getLimitedUseToken(completion:)")));
+		[Export ("getLimitedUseTokenWithCompletion:")]
+		void GetLimitedUseTokenWithCompletion (TokenCompletionHandler handler);
 	}
 
 	// @interface FIRAppCheckDebugProviderFactory : NSObject <FIRAppCheckProviderFactory>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -12,6 +12,13 @@ using Foundation;
 using ObjCRuntime;
 #endif
 
+#if ENABLE_RUNTIME_DRIFT_CASE_APPCHECK_LIMITED_USE_TOKENS
+using Firebase.AppCheck;
+using FirebaseCoreApp = Firebase.Core.App;
+using Foundation;
+using ObjCRuntime;
+#endif
+
 #if ENABLE_RUNTIME_DRIFT_CASE_REMOTECONFIG_REALTIME_CUSTOMSIGNALS
 using Firebase.RemoteConfig;
 using Foundation;
@@ -327,6 +334,160 @@ static class FirebaseRuntimeDriftCases
         finally
         {
             Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
+#endif
+
+#if ENABLE_RUNTIME_DRIFT_CASE_APPCHECK_LIMITED_USE_TOKENS
+    static async Task<string> VerifyAppCheckLimitedUseTokensAsync()
+    {
+        const string limitedUseSelector = "limitedUseTokenWithCompletion:";
+        const string providerLimitedUseSelector = "getLimitedUseTokenWithCompletion:";
+
+        RequireVoidMethod(
+            typeof(AppCheck),
+            nameof(AppCheck.LimitedUseTokenWithCompletion),
+            new[] { typeof(TokenCompletionHandler) },
+            limitedUseSelector);
+        RequireVoidMethod(
+            typeof(AppCheckProvider),
+            nameof(AppCheckProvider.GetLimitedUseTokenWithCompletion),
+            new[] { typeof(TokenCompletionHandler) },
+            providerLimitedUseSelector);
+        RequireVoidMethod(
+            typeof(AppCheckDebugProvider),
+            nameof(AppCheckDebugProvider.GetLimitedUseTokenWithCompletion),
+            new[] { typeof(TokenCompletionHandler) },
+            providerLimitedUseSelector);
+        RequireVoidMethod(
+            typeof(DeviceCheckProvider),
+            nameof(DeviceCheckProvider.GetLimitedUseTokenWithCompletion),
+            new[] { typeof(TokenCompletionHandler) },
+            providerLimitedUseSelector);
+        RequireVoidMethod(
+            typeof(AppAttestProvider),
+            nameof(AppAttestProvider.GetLimitedUseTokenWithCompletion),
+            new[] { typeof(TokenCompletionHandler) },
+            providerLimitedUseSelector);
+
+        var defaultApp = FirebaseCoreApp.DefaultInstance
+            ?? throw new InvalidOperationException("Firebase.Core.App.DefaultInstance returned null before App Check limited-use validation.");
+        var appCheck = AppCheck.SharedInstance
+            ?? throw new InvalidOperationException("Firebase.AppCheck.AppCheck.SharedInstance returned null after App.Configure().");
+
+        if (!appCheck.RespondsToSelector(new Selector(limitedUseSelector)))
+        {
+            throw new InvalidOperationException($"Native FIRAppCheck does not respond to expected selector '{limitedUseSelector}'.");
+        }
+
+        var debugProvider = new AppCheckDebugProvider(defaultApp);
+        if (debugProvider.Handle != NativeHandle.Zero && !debugProvider.RespondsToSelector(new Selector(providerLimitedUseSelector)))
+        {
+            throw new InvalidOperationException($"Native FIRAppCheckDebugProvider does not respond to expected selector '{providerLimitedUseSelector}'.");
+        }
+
+        var completionInvoked = false;
+        var debugProviderCompletionInvoked = false;
+        AppCheckToken? completionToken = null;
+        NSError? completionError = null;
+        NSException? marshaledException = null;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+        var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledException ??= args.Exception;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            try
+            {
+                appCheck.LimitedUseTokenWithCompletion((token, error) =>
+                {
+                    completionInvoked = true;
+                    completionToken = token;
+                    completionError = error;
+                    completionSource.TrySetResult(true);
+                });
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{limitedUseSelector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
+                    $"Completion delegate type: {typeof(TokenCompletionHandler).FullName}. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            if (debugProvider.Handle != NativeHandle.Zero)
+            {
+                try
+                {
+                    debugProvider.GetLimitedUseTokenWithCompletion((token, error) =>
+                    {
+                        debugProviderCompletionInvoked = true;
+                    });
+                }
+                catch (ObjCException ex)
+                {
+                    throw new InvalidOperationException(
+                        $"Selector '{providerLimitedUseSelector}' on FIRAppCheckDebugProvider should not throw after the missing binding is added, " +
+                        $"but observed {ex.GetType().FullName}. Completion delegate type: {typeof(TokenCompletionHandler).FullName}. " +
+                        $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                        $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                        $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                        ex);
+                }
+            }
+
+            var completedTask = await Task.WhenAny(completionSource.Task, Task.Delay(AsyncTimeout));
+            if (completedTask != completionSource.Task)
+            {
+                throw new TimeoutException(
+                    $"Selector '{limitedUseSelector}' did not invoke its completion callback within {AsyncTimeout.TotalSeconds} seconds. " +
+                    $"Completion delegate type: {typeof(TokenCompletionHandler).FullName}.");
+            }
+
+            if (!completionInvoked)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{limitedUseSelector}' completed without throwing, but the completion callback was never marked as invoked.");
+            }
+
+            if (marshaledException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{limitedUseSelector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
+                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            return
+                $"Selector '{limitedUseSelector}' crossed the native boundary and invoked its completion callback. " +
+                $"Completion delegate type: {typeof(TokenCompletionHandler).FullName}. " +
+                $"Token returned: {completionToken is not null}. " +
+                $"NSError: {FormatDetail(completionError?.LocalizedDescription)}. " +
+                $"Provider selector '{providerLimitedUseSelector}' was present on FIRAppCheckDebugProvider: {debugProvider.Handle != NativeHandle.Zero}. " +
+                $"Debug provider callback invoked during probe: {debugProviderCompletionInvoked}.";
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+
+        static void RequireVoidMethod(Type type, string methodName, Type[] parameterTypes, string selector)
+        {
+            var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, binder: null, types: parameterTypes, modifiers: null);
+            if (method?.ReturnType != typeof(void))
+            {
+                throw new InvalidOperationException(
+                    $"Expected managed API '{type.FullName}.{methodName}({string.Join(", ", parameterTypes.Select(parameterType => parameterType.FullName))})' " +
+                    $"to return void for selector '{selector}', observed '{method?.ReturnType.FullName ?? "<missing>"}'.");
+            }
         }
     }
 #endif

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -13,6 +13,17 @@
       "packages": []
     },
     {
+      "id": "appcheck-limited-use-tokens",
+      "method": "VerifyAppCheckLimitedUseTokensAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.AppCheck",
+      "packages": [
+        {
+          "id": "AdamE.Firebase.iOS.AppCheck",
+          "version": "12.6.0"
+        }
+      ]
+    },
+    {
       "id": "remoteconfig-realtime-customsignals",
       "method": "VerifyRemoteConfigRealtimeCustomSignalsAsync",
       "bindingPackage": "AdamE.Firebase.iOS.RemoteConfig",


### PR DESCRIPTION
## Summary

- Adds the missing AppCheck limited-use token selector `limitedUseTokenWithCompletion:`.
- Adds the optional provider selector `getLimitedUseTokenWithCompletion:` to the AppCheck provider model and exposes it on `AppCheckDebugProvider`, which does not inherit the model surface directly.
- Adds the targeted local E2E runtime drift case `appcheck-limited-use-tokens`.

## Notes

This keeps the binding thin: no task wrapper or convenience helper is added. The E2E case treats native App Check configuration/platform errors as acceptable after the selector crosses the native boundary, and still fails on binding-layer issues such as missing managed API, unrecognized selector, bad marshaling, or `ObjCRuntime.ObjCException`.

Out of scope for this slice: unrelated AppCheck provider APIs, audit tooling, Firestore cache settings, and broader backlog cleanup.

## Validation

- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.AppCheck"`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case appcheck-limited-use-tokens`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug`
- `git diff --check`

Targeted E2E result: `RuntimeDrift:appcheck-limited-use-tokens` passed. The native selector `limitedUseTokenWithCompletion:` invoked its callback and returned a native App Check platform/OS error on simulator rather than a binding-layer exception.