### PR TITLE
Refactor Firebase E2E drift test helpers

### DIFF
--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.Helpers.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.Helpers.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+using Foundation;
+using ObjCRuntime;
+
+namespace FirebaseFoundationE2E;
+
+static partial class FirebaseRuntimeDriftCases
+{
+    sealed class ObjCExceptionProbe : IDisposable
+    {
+        bool disposed;
+
+        ObjCExceptionProbe()
+        {
+            Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        }
+
+        public static ObjCExceptionProbe Attach()
+        {
+            return new ObjCExceptionProbe();
+        }
+
+        public NSException? Exception { get; private set; }
+
+        public MarshalObjectiveCExceptionMode? ExceptionMode { get; private set; }
+
+        public bool HasException => Exception is not null;
+
+        public string Name => FormatDetail(Exception?.Name?.ToString());
+
+        public string Reason => FormatDetail(Exception?.Reason);
+
+        public string Mode => FormatDetail(ExceptionMode?.ToString());
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            disposed = true;
+        }
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            Exception ??= args.Exception;
+            ExceptionMode ??= args.ExceptionMode;
+        }
+    }
+
+    static string FormatNSError(NSError error)
+    {
+        return $"{error.Domain} ({error.Code}): {error.LocalizedDescription}";
+    }
+
+    static void RequireConstructor(Type type, Type[] parameterTypes, string selector)
+    {
+        var constructor = type.GetConstructor(parameterTypes);
+        if (constructor is null)
+        {
+            throw new InvalidOperationException(
+                $"Expected managed constructor '{type.FullName}({string.Join(", ", parameterTypes.Select(parameterType => parameterType.FullName))})' " +
+                $"was not found for selector '{selector}'.");
+        }
+    }
+
+    static void RequireVoidMethod(Type type, string methodName, string selector)
+    {
+        RequireVoidMethod(type, methodName, Type.EmptyTypes, selector);
+    }
+
+    static void RequireVoidMethod(Type type, string methodName, Type[] parameterTypes, string selector)
+    {
+        var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, binder: null, types: parameterTypes, modifiers: null);
+        if (method?.ReturnType != typeof(void))
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{type.FullName}.{methodName}({string.Join(", ", parameterTypes.Select(parameterType => parameterType.FullName))})' " +
+                $"to return void for selector '{selector}', observed '{method?.ReturnType.FullName ?? "<missing>"}'.");
+        }
+    }
+
+    static string FormatDetail(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "<empty>" : value;
+    }
+}

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -104,7 +104,7 @@ using ObjCRuntime;
 
 namespace FirebaseFoundationE2E;
 
-static class FirebaseRuntimeDriftCases
+static partial class FirebaseRuntimeDriftCases
 {
     static readonly TimeSpan AsyncTimeout = TimeSpan.FromSeconds(5);
 
@@ -177,17 +177,9 @@ static class FirebaseRuntimeDriftCases
         var callbackInvoked = false;
         long callbackSessionId = 0;
         NSError? callbackError = null;
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
         var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -205,9 +197,9 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Selector '{selector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
                     $"Completion delegate type: {typeof(Action<long, NSError>).FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
@@ -224,11 +216,11 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{selector}' completed without throwing, but the completion callback was never marked as invoked.");
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return
@@ -239,7 +231,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -282,16 +274,7 @@ static class FirebaseRuntimeDriftCases
             }
         }
 
-        var marshaledExceptionCaptured = false;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
-
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledExceptionCaptured = true;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             using var hashedEmailAddress = NSData.FromArray(new byte[]
@@ -322,15 +305,15 @@ static class FirebaseRuntimeDriftCases
                     "Analytics on-device conversion selectors should not throw after the missing bindings are added, " +
                     $"but observed {ex.GetType().FullName}. " +
                     $"String argument type: {typeof(string).FullName}. Hashed argument type: {typeof(NSData).FullName}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledExceptionCaptured)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
                     "Analytics on-device conversion selectors completed, but Runtime.MarshalObjectiveCException captured an unexpected Objective-C exception. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return Task.FromResult(
@@ -339,7 +322,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -396,17 +379,9 @@ static class FirebaseRuntimeDriftCases
         var debugProviderCompletionInvoked = false;
         AppCheckToken? completionToken = null;
         NSError? completionError = null;
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
         var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -424,9 +399,9 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Selector '{limitedUseSelector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
                     $"Completion delegate type: {typeof(TokenCompletionHandler).FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
@@ -444,9 +419,9 @@ static class FirebaseRuntimeDriftCases
                     throw new InvalidOperationException(
                         $"Selector '{providerLimitedUseSelector}' on FIRAppCheckDebugProvider should not throw after the missing binding is added, " +
                         $"but observed {ex.GetType().FullName}. Completion delegate type: {typeof(TokenCompletionHandler).FullName}. " +
-                        $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                        $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                        $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                        $"NSException.Name: {objcExceptionProbe.Name}. " +
+                        $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                        $"Marshal mode: {objcExceptionProbe.Mode}.",
                         ex);
                 }
             }
@@ -465,11 +440,11 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{limitedUseSelector}' completed without throwing, but the completion callback was never marked as invoked.");
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Selector '{limitedUseSelector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Selector '{limitedUseSelector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return
@@ -482,19 +457,9 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
 
-        static void RequireVoidMethod(Type type, string methodName, Type[] parameterTypes, string selector)
-        {
-            var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, binder: null, types: parameterTypes, modifiers: null);
-            if (method?.ReturnType != typeof(void))
-            {
-                throw new InvalidOperationException(
-                    $"Expected managed API '{type.FullName}.{methodName}({string.Join(", ", parameterTypes.Select(parameterType => parameterType.FullName))})' " +
-                    $"to return void for selector '{selector}', observed '{method?.ReturnType.FullName ?? "<missing>"}'.");
-            }
-        }
     }
 #endif
 
@@ -555,17 +520,9 @@ static class FirebaseRuntimeDriftCases
         NSError? listenerError = null;
         var customSignalsCompletionInvoked = false;
         NSError? customSignalsCompletionError = null;
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
         var customSignalsCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             using var signalKey = new NSString("codex_signal");
@@ -590,9 +547,9 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Selector '{listenerSelector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
                     $"Listener delegate type: {typeof(RemoteConfigUpdateCompletionHandler).FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
@@ -620,18 +577,18 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Selector '{customSignalsSelector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
                     $"Signals dictionary type: {customSignals.GetType().FullName}. Completion delegate type: {typeof(Action<NSError>).FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
             var completedTask = await Task.WhenAny(customSignalsCompletionSource.Task, Task.Delay(AsyncTimeout));
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"RemoteConfig missing-surface selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"RemoteConfig missing-surface selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             if (completedTask != customSignalsCompletionSource.Task)
@@ -655,7 +612,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -678,16 +635,8 @@ static class FirebaseRuntimeDriftCases
         }
 
         using var delta = NSNumber.FromInt64(1);
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             NSDictionary placeholder;
@@ -700,17 +649,17 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Selector '{selector}' should not throw for a valid NSNumber delta, but observed {ex.GetType().FullName}. " +
                     $"Managed delta argument type: {delta.GetType().FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             if (placeholder.Count == 0)
@@ -724,7 +673,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -779,17 +728,9 @@ static class FirebaseRuntimeDriftCases
         var payloads = Array.Empty<NSData>();
         var completionInvoked = false;
         NSError? completionError = null;
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
         var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -807,9 +748,9 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{selector}' should not throw with the corrected enum binding, but observed {ex.GetType().FullName}. " +
                     $"Managed policy argument type: {policy.GetType().FullName}. Policy value: {(int)policy}. " +
                     $"Payload array type: {payloads.GetType().FullName}. Payload count: {payloads.Length}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
@@ -826,11 +767,11 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{selector}' completed without throwing, but the completion callback was never marked as invoked.");
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return
@@ -841,7 +782,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -859,16 +800,8 @@ static class FirebaseRuntimeDriftCases
 
         var payload = new ExperimentPayload();
         var origin = "codex";
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -881,17 +814,17 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{selector}' should not throw after the binding fix, but observed {ex.GetType().FullName}. " +
                     $"Managed payload type: {payload.GetType().FullName}. " +
                     $"Origin argument type: {origin.GetType().FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return Task.FromResult(
@@ -901,7 +834,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -938,16 +871,8 @@ static class FirebaseRuntimeDriftCases
 
         var payloads = Array.Empty<ExperimentPayload>();
         var origin = "codex";
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -960,17 +885,17 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{selector}' should not throw after the binding fix, but observed {ex.GetType().FullName}. " +
                     $"Managed payload array type: {payloads.GetType().FullName}. Payload count: {payloads.Length}. " +
                     $"Origin argument type: {origin.GetType().FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return Task.FromResult(
@@ -981,7 +906,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -1000,17 +925,9 @@ static class FirebaseRuntimeDriftCases
         var queryName = "codex-firestore-missing-query";
         var callbackInvoked = false;
         var returnedQueryWasNull = false;
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
         var completionSource = new TaskCompletionSource<Query?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -1027,9 +944,9 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Selector '{selector}' should not throw after the binding fix, but observed {ex.GetType().FullName}. " +
                     $"Runtime argument type: {queryName.GetType().FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
@@ -1047,11 +964,11 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{selector}' completed without throwing, but the completion callback was never marked as invoked.");
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return
@@ -1063,7 +980,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -1105,17 +1022,9 @@ static class FirebaseRuntimeDriftCases
         using var first = NSNumber.FromInt64(1);
         using var second = NSNumber.FromInt64(2);
         var values = new[] { first, second };
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
         var vectorArrayLength = 0;
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -1142,17 +1051,17 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{selector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
                     $"Managed vector argument type: {values.GetType().FullName}. " +
                     $"Vector value type: {typeof(VectorValue).FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return Task.FromResult(
@@ -1162,7 +1071,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -1283,16 +1192,7 @@ static class FirebaseRuntimeDriftCases
             throw new InvalidOperationException($"Native FIRQuery does not respond to expected selector '{queryWhereFieldPathNotInSelector}'.");
         }
 
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
-
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             Query stringNotEqualQuery;
@@ -1324,17 +1224,17 @@ static class FirebaseRuntimeDriftCases
                     $"Firestore query filter selectors should not throw after the missing bindings are added, but observed {ex.GetType().FullName}. " +
                     $"Selectors exercised: setData:completion:, '{queryWhereFilterSelector}', '{queryWhereFieldNotEqualSelector}', " +
                     $"'{queryWhereFieldPathNotEqualSelector}', '{queryWhereFieldNotInSelector}', '{queryWhereFieldPathNotInSelector}', '{filterWhereFieldNotInSelector}'. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Firestore query filter selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Firestore query filter selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             var stringNotEqualCount = await GetServerCountAsync(stringNotEqualQuery, "string notEqualTo query");
@@ -1357,7 +1257,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
 
         async Task SetSeedDocumentAsync(string documentId, string group, string color, int score)
@@ -1457,11 +1357,11 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException($"Cloud Firestore {label} completed without either a snapshot or an NSError.");
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Cloud Firestore {label} completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Cloud Firestore {label} completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return (int)completedSnapshot.Count;
@@ -1605,16 +1505,7 @@ static class FirebaseRuntimeDriftCases
                 $"Native FIRQuery does not respond to expected selector '{addSnapshotListenerWithOptionsSelector}'.");
         }
 
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
-
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         IListenerRegistration? documentRegistration = null;
         IListenerRegistration? queryRegistration = null;
         var documentCallbackSource = new TaskCompletionSource<(DocumentSnapshot? Snapshot, NSError? Error)>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1671,9 +1562,9 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Firestore snapshot listen option selectors should not throw after the missing bindings are added, but observed {ex.GetType().FullName}. " +
                     $"Selectors exercised: '{optionsWithIncludeMetadataChangesSelector}', '{optionsWithSourceSelector}', '{addSnapshotListenerWithOptionsSelector}'. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
@@ -1693,11 +1584,11 @@ static class FirebaseRuntimeDriftCases
                 Task.WhenAll(documentCallbackSource.Task, queryCallbackSource.Task),
                 Task.Delay(TimeSpan.FromMilliseconds(500)));
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Firestore snapshot listen option selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Firestore snapshot listen option selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             var documentCallbackDetail = documentCallbackSource.Task.IsCompletedSuccessfully
@@ -1723,7 +1614,7 @@ static class FirebaseRuntimeDriftCases
             finally
             {
                 queryRegistration?.Remove();
-                Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+                objcExceptionProbe.Dispose();
             }
         }
 
@@ -1838,19 +1729,10 @@ static class FirebaseRuntimeDriftCases
         {
             throw new InvalidOperationException($"Native FIRQuery does not respond to expected selector '{aggregateSelector}'.");
         }
-
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
         var seedWriteCompletionSource = new TaskCompletionSource<NSError?>(TaskCreationOptions.RunContinuationsAsynchronously);
         var serverCountCompletionSource = new TaskCompletionSource<(AggregateQuerySnapshot? Snapshot, NSError? Error)>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             AggregateField countField;
@@ -1944,17 +1826,17 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Firestore aggregate selectors should not throw after the missing bindings are added, but observed {ex.GetType().FullName}. " +
                     $"Selectors exercised: setData:completion:, '{queryCountSelector}', '{aggregateSelector}', '{aggregateQueryQuerySelector}', '{getAggregationSelector}', aggregateFieldForCount, aggregateFieldForSumOfField:, aggregateFieldForSumOfFieldPath:, aggregateFieldForAverageOfField:, aggregateFieldForAverageOfFieldPath:. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Firestore aggregate selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Firestore aggregate selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             if (countQuery is null)
@@ -2001,11 +1883,11 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException("Server count aggregation callback state did not match the completed task payload.");
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Firestore aggregate server query completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Firestore aggregate server query completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             var serverResultDetail = completedServerCountError is not null
@@ -2042,7 +1924,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 
@@ -2085,16 +1967,8 @@ static class FirebaseRuntimeDriftCases
 
         var defaultApp = Firebase.Core.App.DefaultInstance
             ?? throw new InvalidOperationException("Firebase.Core.App.DefaultInstance returned null after App.Configure().");
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
 
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             Firestore? defaultNamedDatabase = null;
@@ -2110,9 +1984,9 @@ static class FirebaseRuntimeDriftCases
                     $"Firestore named-database selectors should not throw after the missing bindings are added, but observed {ex.GetType().FullName}. " +
                     $"Selectors exercised: '{firestoreForDatabaseSelector}', '{firestoreForAppDatabaseSelector}'. " +
                     $"Database id: {databaseId}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
@@ -2140,11 +2014,11 @@ static class FirebaseRuntimeDriftCases
                     $"Firestore instance from selector '{firestoreForAppDatabaseSelector}' could not create a collection reference.");
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Firestore named-database selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Firestore named-database selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return Task.FromResult(
@@ -2156,7 +2030,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -2216,16 +2090,7 @@ static class FirebaseRuntimeDriftCases
                 $"Native FIRFirestore does not respond to expected selector '{persistentCacheIndexManagerSelector}'.");
         }
 
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
-
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             string cacheSettingsRuntimeTypes;
@@ -2315,17 +2180,17 @@ static class FirebaseRuntimeDriftCases
                     $"Selectors exercised: '{cacheSettingsSelector}', '{setCacheSettingsSelector}', '{persistentCacheIndexManagerSelector}', " +
                     $"'{enableIndexAutoCreationSelector}', '{disableIndexAutoCreationSelector}', '{deleteAllIndexesSelector}', " +
                     $"initWithSizeBytes:, initWithGarbageCollectorSettings:. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Firestore cache settings selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Firestore cache settings selectors completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return Task.FromResult(
@@ -2337,29 +2202,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
-        }
-
-        static void RequireConstructor(Type type, Type[] parameterTypes, string selector)
-        {
-            var constructor = type.GetConstructor(parameterTypes);
-            if (constructor is null)
-            {
-                throw new InvalidOperationException(
-                    $"Expected managed constructor '{type.FullName}({string.Join(", ", parameterTypes.Select(parameterType => parameterType.FullName))})' " +
-                    $"was not found for selector '{selector}'.");
-            }
-        }
-
-        static void RequireVoidMethod(Type type, string methodName, string selector)
-        {
-            var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, binder: null, Type.EmptyTypes, modifiers: null);
-            if (method?.ReturnType != typeof(void))
-            {
-                throw new InvalidOperationException(
-                    $"Expected managed API '{type.FullName}.{methodName}()' to return void for selector '{selector}', " +
-                    $"observed '{method?.ReturnType.FullName ?? "<missing>"}'.");
-            }
+            objcExceptionProbe.Dispose();
         }
 
         static string RequireCacheSettings(FirestoreSettings settings, string assignedRuntimeTypeName)
@@ -2415,16 +2258,7 @@ static class FirebaseRuntimeDriftCases
                 $"Native FIRFunctions does not respond to expected live selector '{liveSelector}'.");
         }
 
-        NSException? marshaledException = null;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
-
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledException ??= args.Exception;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -2436,17 +2270,17 @@ static class FirebaseRuntimeDriftCases
                 throw new InvalidOperationException(
                     $"Selector '{liveSelector}' should not throw after the binding fix, but observed {ex.GetType().FullName}. " +
                     $"Runtime host argument type: {typeof(string).FullName}. Runtime port argument type: {typeof(uint).FullName}. " +
-                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
-                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    $"NSException.Name: {objcExceptionProbe.Name}. " +
+                    $"NSException.Reason: {objcExceptionProbe.Reason}. " +
+                    $"Marshal mode: {objcExceptionProbe.Mode}.",
                     ex);
             }
 
-            if (marshaledException is not null)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
-                    $"Cloud Functions emulator API completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
-                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Cloud Functions emulator API completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{objcExceptionProbe.Name}'. " +
+                    $"Reason: {objcExceptionProbe.Reason}. Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return Task.FromResult(
@@ -2456,7 +2290,7 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
@@ -2479,16 +2313,7 @@ static class FirebaseRuntimeDriftCases
                 $"Expected managed API '{nameof(StackFrame.Create)}({typeof(nuint).FullName})' was not found.");
         }
 
-        var marshaledExceptionCaptured = false;
-        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
-
-        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
-        {
-            marshaledExceptionCaptured = true;
-            marshaledExceptionMode ??= args.ExceptionMode;
-        }
-
-        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        var objcExceptionProbe = ObjCExceptionProbe.Attach();
         try
         {
             try
@@ -2506,14 +2331,14 @@ static class FirebaseRuntimeDriftCases
                     $"Selector '{liveSelector}' should not throw after the binding fix, but observed {ex.GetType().FullName}. " +
                     $"Stale selector was '{staleSelector}'. " +
                     $"Runtime address argument type: {typeof(nuint).FullName}. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
-            if (marshaledExceptionCaptured)
+            if (objcExceptionProbe.HasException)
             {
                 throw new InvalidOperationException(
                     $"Selector '{liveSelector}' completed, but Runtime.MarshalObjectiveCException captured an unexpected Objective-C exception. " +
-                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+                    $"Marshal mode: {objcExceptionProbe.Mode}.");
             }
 
             return Task.FromResult(
@@ -2522,18 +2347,9 @@ static class FirebaseRuntimeDriftCases
         }
         finally
         {
-            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+            objcExceptionProbe.Dispose();
         }
     }
 #endif
 
-    static string FormatNSError(Foundation.NSError error)
-    {
-        return $"{error.Domain} ({error.Code}): {error.LocalizedDescription}";
-    }
-
-    static string FormatDetail(string? value)
-    {
-        return string.IsNullOrWhiteSpace(value) ? "<empty>" : value;
-    }
 }


### PR DESCRIPTION
## Summary
- Extract reusable runtime-drift E2E helpers into a new partial class file
- Centralize Objective-C exception capture with `ObjCExceptionProbe`
- Share constructor and void-method reflection assertions while keeping per-test selector evidence visible

## Validation
- `dotnet build tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj -f net9.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableRuntimeDriftCase=false --no-restore`
- `dotnet build tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj --configuration Debug --framework net9.0-ios --no-restore -p:Platform=iPhoneSimulator -p:RuntimeIdentifier=iossimulator-arm64 -p:RuntimeDriftCasePropsPath=tests/E2E/Firebase.Foundation/artifacts/runtime-drift-all.generated.props`
- `git diff --check`

Notes: both builds passed with the existing iOS orientation warning only.