### PR TITLE
Add Crashlytics recordError userInfo binding

### DIFF
--- a/source/Firebase/Crashlytics/ApiDefinition.cs
+++ b/source/Firebase/Crashlytics/ApiDefinition.cs
@@ -39,6 +39,10 @@ namespace Firebase.Crashlytics {
 		[Export ("recordError:")]
 		void RecordError (NSError error);
 
+		// -(void)recordError:(NSError * _Nonnull)error userInfo:(NSDictionary<NSString *,id> * _Nullable)userInfo __attribute__((swift_name("record(error:userInfo:)")));
+		[Export ("recordError:userInfo:")]
+		void RecordError (NSError error, [NullAllowed] NSDictionary<NSString, NSObject> userInfo);
+
 		// -(void)recordExceptionModel:(FIRExceptionModel * _Nonnull)exceptionModel __attribute__((swift_name("record(exceptionModel:)")));
 		[Export ("recordExceptionModel:")]
 		void RecordExceptionModel (ExceptionModel exceptionModel);

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -97,8 +97,9 @@ using Foundation;
 using ObjCRuntime;
 #endif
 
-#if ENABLE_RUNTIME_DRIFT_CASE_CRASHLYTICS_STACKFRAMEWITHADDRESS
+#if ENABLE_RUNTIME_DRIFT_CASE_CRASHLYTICS_STACKFRAMEWITHADDRESS || ENABLE_RUNTIME_DRIFT_CASE_CRASHLYTICS_RECORD_ERROR_USER_INFO
 using Firebase.Crashlytics;
+using Foundation;
 using ObjCRuntime;
 #endif
 
@@ -2519,6 +2520,88 @@ static class FirebaseRuntimeDriftCases
             return Task.FromResult(
                 $"Corrected stale selector '{staleSelector}' to native selector '{liveSelector}'. " +
                 $"Runtime address argument type: {typeof(nuint).FullName}; StackFrame.Create returned without ObjC exception.");
+        }
+        finally
+        {
+            Runtime.MarshalObjectiveCException -= OnMarshalObjectiveCException;
+        }
+    }
+#endif
+
+#if ENABLE_RUNTIME_DRIFT_CASE_CRASHLYTICS_RECORD_ERROR_USER_INFO
+    static Task<string> VerifyCrashlyticsRecordErrorUserInfoAsync()
+    {
+        const string selector = "recordError:userInfo:";
+
+        var signature = typeof(Crashlytics).GetMethod(
+            nameof(Crashlytics.RecordError),
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(NSError), typeof(NSDictionary<NSString, NSObject>) },
+            modifiers: null);
+        if (signature is null)
+        {
+            throw new InvalidOperationException(
+                $"Expected managed API '{nameof(Crashlytics.RecordError)}({typeof(NSError).FullName}, {typeof(NSDictionary<NSString, NSObject>).FullName})' was not found.");
+        }
+
+        var crashlytics = Crashlytics.SharedInstance;
+        if (crashlytics is null)
+        {
+            throw new InvalidOperationException("Firebase.Crashlytics.Crashlytics.SharedInstance returned null after App.Configure().");
+        }
+
+        if (!crashlytics.RespondsToSelector(new Selector(selector)))
+        {
+            throw new InvalidOperationException($"Native FIRCrashlytics does not respond to expected selector '{selector}'.");
+        }
+
+        using var domain = new NSString("codex.crashlytics.e2e");
+        using var userInfoKey = new NSString("codex_context");
+        using var userInfoValue = new NSString("record-error-user-info");
+        using var error = new NSError(domain, -130, null);
+        using var userInfo = NSDictionary<NSString, NSObject>.FromObjectsAndKeys(
+            new NSObject[] { userInfoValue },
+            new[] { userInfoKey },
+            1);
+
+        NSException? marshaledException = null;
+        MarshalObjectiveCExceptionMode? marshaledExceptionMode = null;
+
+        void OnMarshalObjectiveCException(object? sender, MarshalObjectiveCExceptionEventArgs args)
+        {
+            marshaledException ??= args.Exception;
+            marshaledExceptionMode ??= args.ExceptionMode;
+        }
+
+        Runtime.MarshalObjectiveCException += OnMarshalObjectiveCException;
+        try
+        {
+            try
+            {
+                crashlytics.RecordError(error, userInfo);
+            }
+            catch (ObjCException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' should not throw after the missing binding is added, but observed {ex.GetType().FullName}. " +
+                    $"NSError domain: {error.Domain}. UserInfo type: {userInfo.GetType().FullName}. " +
+                    $"NSException.Name: {FormatDetail(marshaledException?.Name?.ToString())}. " +
+                    $"NSException.Reason: {FormatDetail(marshaledException?.Reason)}. " +
+                    $"Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.",
+                    ex);
+            }
+
+            if (marshaledException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Selector '{selector}' completed, but Runtime.MarshalObjectiveCException captured unexpected NSException.Name '{marshaledException.Name}'. " +
+                    $"Reason: {FormatDetail(marshaledException.Reason)}. Marshal mode: {FormatDetail(marshaledExceptionMode?.ToString())}.");
+            }
+
+            return Task.FromResult(
+                $"Selector '{selector}' crossed the native boundary without ObjC exception. " +
+                $"NSError domain: {error.Domain}. UserInfo count: {userInfo.Count}.");
         }
         finally
         {

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -180,6 +180,17 @@
           "version": "12.6.0"
         }
       ]
+    },
+    {
+      "id": "crashlytics-record-error-user-info",
+      "method": "VerifyCrashlyticsRecordErrorUserInfoAsync",
+      "bindingPackage": "AdamE.Firebase.iOS.Crashlytics",
+      "packages": [
+        {
+          "id": "AdamE.Firebase.iOS.Crashlytics",
+          "version": "12.6.0"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the missing Firebase Crashlytics binding for `recordError:userInfo:` as `Crashlytics.RecordError(NSError, NSDictionary<NSString, NSObject>)`.
- Adds a targeted Firebase Foundation runtime-drift case, `crashlytics-record-error-user-info`, to exercise the new overload and verify it crosses the native selector boundary without an Objective-C exception.

## Header evidence
- Source of truth: `externals/FirebaseCrashlytics.xcframework/ios-arm64_x86_64-simulator/FirebaseCrashlytics.framework/Headers/FIRCrashlytics.h`
- Native declaration: `- (void)recordError:(NSError *)error userInfo:(nullable NSDictionary<NSString *, id> *)userInfo NS_SWIFT_NAME(record(error:userInfo:));`
- Native selector: `recordError:userInfo:`

## Validation
- `dotnet tool restore`
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.Crashlytics"`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case crashlytics-record-error-user-info`
- `git diff --check`

## Out of scope
- Audit tooling and generated audit output.
- Other missing-binding findings from the fresh audit.
- Existing untracked local workflow/script files.