### PR TITLE
Add AppCheck debug provider token binding

### DIFF
--- a/source/Firebase/AppCheck/ApiDefinition.cs
+++ b/source/Firebase/AppCheck/ApiDefinition.cs
@@ -103,7 +103,7 @@ namespace Firebase.AppCheck {
 	// @interface FIRAppCheckDebugProvider : NSObject <FIRAppCheckProvider>	
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRAppCheckDebugProvider")]
-	interface AppCheckDebugProvider : IAppCheckProvider {
+	interface AppCheckDebugProvider : AppCheckProvider {
 		// -(instancetype _Nullable)initWithApp:(FIRApp * _Nonnull)app;
 		[return: NullAllowed]
 		[Export ("initWithApp:")]
@@ -117,9 +117,6 @@ namespace Firebase.AppCheck {
 		[Export ("currentDebugToken")]
 		string CurrentDebugToken { get; }
 
-		// -(void)getLimitedUseTokenWithCompletion:(void (^ _Nonnull)(FIRAppCheckToken * _Nullable, NSError * _Nullable))handler __attribute__((swift_name("getLimitedUseToken(completion:)")));
-		[Export ("getLimitedUseTokenWithCompletion:")]
-		void GetLimitedUseTokenWithCompletion (TokenCompletionHandler handler);
 	}
 
 	// @interface FIRAppCheckDebugProviderFactory : NSObject <FIRAppCheckProviderFactory>


### PR DESCRIPTION
## Summary
- Aligns `AppCheckDebugProvider` with the other concrete App Check providers by inheriting the bound `AppCheckProvider` protocol surface.
- This exposes `GetTokenWithCompletion(...)` on `AppCheckDebugProvider` and preserves `GetLimitedUseTokenWithCompletion(...)` through the shared protocol binding.
- The generated binding now emits `AppCheckDebugProvider : NSObject, IAppCheckProvider` with both token methods.

## Header evidence
- Source of truth: `externals/FirebaseAppCheck.xcframework/ios-arm64_x86_64-simulator/FirebaseAppCheck.framework/Headers/FIRAppCheckDebugProvider.h`
- Native declaration: `@interface FIRAppCheckDebugProvider : NSObject <FIRAppCheckProvider>`
- Native selectors copied into the concrete provider header: `getTokenWithCompletion:` and `getLimitedUseTokenWithCompletion:`

## Validation
- `dotnet tool restore`
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.AppCheck"`
- `git diff --check`
- Generated-source sanity check: `AppCheckDebugProvider.g.cs` includes `IAppCheckProvider`, `GetTokenWithCompletion`, and `GetLimitedUseTokenWithCompletion`.

## E2E note
- No targeted E2E case is included in this branch so this PR stays independent from the already-open runtime-drift manifest changes in #131. This API is also App Check provider/environment-sensitive, so package plus generated-surface validation is the tighter signal for this isolated binding-gap PR.

## Out of scope
- Other App Check audit findings that are already covered by protocol inheritance on `DeviceCheckProvider` and `AppAttestProvider`.
- Audit tooling and generated audit output.