### PR TITLE
Add Firestore transaction options binding

### DIFF
--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -687,6 +687,11 @@ namespace Firebase.CloudFirestore
 		[Export ("runTransactionWithBlock:completion:")]
 		void _RunTransaction (Func<Transaction, IntPtr, NSObject> updateHandler, TransactionCompletionHandler completion);
 
+		// -(void)runTransactionWithOptions:(FIRTransactionOptions * _Nullable)options block:(id  _Nullable (^ _Nonnull)(FIRTransaction * _Nonnull, NSError * _Nullable * _Nullable))updateBlock completion:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completion;
+		[Internal]
+		[Export ("runTransactionWithOptions:block:completion:")]
+		void _RunTransaction ([NullAllowed] TransactionOptions options, Func<Transaction, IntPtr, NSObject> updateHandler, TransactionCompletionHandler completion);
+
 		// -(FIRWriteBatch * _Nonnull)batch;
 		[Export ("batch")]
 		WriteBatch CreateBatch ();
@@ -856,6 +861,15 @@ namespace Firebase.CloudFirestore
 		// - (instancetype _Nonnull)initWithGarbageCollectorSettings:(id<FIRMemoryGarbageCollectorSettings, NSObject> _Nonnull)settings;
 		[Export ("initWithGarbageCollectorSettings:")]
 		NativeHandle Constructor (NSObject settings);
+	}
+
+	// @interface FIRTransactionOptions : NSObject <NSCopying>
+	[BaseType (typeof (NSObject), Name = "FIRTransactionOptions")]
+	interface TransactionOptions : INSCopying
+	{
+		// @property(nonatomic, assign) NSInteger maxAttempts;
+		[Export ("maxAttempts")]
+		nint MaxAttempts { get; set; }
 	}
 
 	// @interface FIRPersistentCacheIndexManager : NSObject

--- a/source/Firebase/CloudFirestore/Extensions.cs
+++ b/source/Firebase/CloudFirestore/Extensions.cs
@@ -46,10 +46,41 @@ namespace Firebase.CloudFirestore
 			}
 		}
 
+		public void RunTransaction (TransactionOptions options, TransactionUpdateHandler updateHandler, TransactionCompletionHandler completion)
+		{
+			_RunTransaction (options, InternalUpdateHandler, completion);
+
+			NSObject InternalUpdateHandler (Transaction transaction, IntPtr pError)
+			{
+				if (updateHandler == null)
+					return null;
+
+				NSError error = null;
+				var result = updateHandler (transaction, ref error);
+
+				if (error != null)
+					Marshal.WriteIntPtr (pError, error.Handle);
+
+				return result;
+			}
+		}
+
 		public Task<NSObject> RunTransactionAsync (TransactionUpdateHandler updateHandler)
 		{
 			var tcs = new TaskCompletionSource<NSObject> ();
 			RunTransaction (updateHandler, (result_, error_) => {
+				if (error_ != null)
+					tcs.SetException (new NSErrorException (error_));
+				else
+					tcs.SetResult (result_);
+			});
+			return tcs.Task;
+		}
+
+		public Task<NSObject> RunTransactionAsync (TransactionOptions options, TransactionUpdateHandler updateHandler)
+		{
+			var tcs = new TaskCompletionSource<NSObject> ();
+			RunTransaction (options, updateHandler, (result_, error_) => {
 				if (error_ != null)
 					tcs.SetException (new NSErrorException (error_));
 				else


### PR DESCRIPTION
## Summary
- Adds the missing Firestore `TransactionOptions` binding for `FIRTransactionOptions`.
- Adds the native `runTransactionWithOptions:block:completion:` binding and exposes it through overloads matching the existing `RunTransaction`/`RunTransactionAsync` smoothing pattern.

## Header evidence
- Source of truth: `externals/FirebaseFirestoreInternal.xcframework/ios-arm64_x86_64-simulator/FirebaseFirestoreInternal.framework/Headers/FIRFirestore.h`
- Native selector: `runTransactionWithOptions:block:completion:`
- Source of truth: `externals/FirebaseFirestoreInternal.xcframework/ios-arm64_x86_64-simulator/FirebaseFirestoreInternal.framework/Headers/FIRTransactionOptions.h`
- Native support type: `FIRTransactionOptions : NSObject <NSCopying>` with `maxAttempts`.

## Validation
- `dotnet tool restore`
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.CloudFirestore"`
- `git diff --check`
- Generated-source sanity check: `TransactionOptions.g.cs` includes `TransactionOptions`/`MaxAttempts`, and `Firestore.g.cs` includes `runTransactionWithOptions:block:completion:`.

## E2E note
- No targeted E2E case is included in this branch so it stays independent from #131, which already edits the shared runtime-drift manifest and case file. This PR is scoped to the binding gap plus package/generated-surface validation.

## Out of scope
- Other Firestore missing-binding findings from the audit.
- Audit tooling and generated audit output.