### PR TITLE
[codex] Remove Core GoogleAppMeasurement podspec

### DIFF
--- a/components.cake
+++ b/components.cake
@@ -184,7 +184,6 @@ void SetArtifactsPodSpecs ()
 		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("FirebaseSessions",            "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("FirebaseSharedSwift",         "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("GoogleAppMeasurement",        "12.6.0"),
 		PodSpec.Create ("PromisesSwift",               "2.4.0",  frameworkSource: FrameworkSource.Pods, frameworkName: "Promises", targetName: "PromisesSwift"),
 		PodSpec.Create ("leveldb-library",             "1.22.6", frameworkSource: FrameworkSource.Pods, frameworkName: "leveldb"),
 	};


### PR DESCRIPTION
## Summary

Removes the stale `GoogleAppMeasurement` podspec entry from the `Firebase.Core` artifact definition in `components.cake`.

## Why

The real Firebase 12.6.0 `FirebaseCore` podspec does not depend on `GoogleAppMeasurement`. Analytics already owns the dedicated `Google.GoogleAppMeasurement` artifact and dependency, so keeping it in Core incorrectly expands the Core source graph.

## Impact

Core packaging metadata now better matches the actual Firebase pod graph while leaving the dedicated GoogleAppMeasurement artifact untouched.

## Validation

- Inspected the staged diff for `components.cake`
- Ran `git diff --cached --check`