### PR TITLE
[codex] Move FirebaseSessions into Installations

### DIFF
--- a/components.cake
+++ b/components.cake
@@ -182,7 +182,6 @@ void SetArtifactsPodSpecs ()
 		PodSpec.Create ("FirebaseCoreInternal",        "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("FirebaseMessagingInterop",    "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseSessions",            "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("FirebaseSharedSwift",         "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("PromisesSwift",               "2.4.0",  frameworkSource: FrameworkSource.Pods, frameworkName: "Promises", targetName: "PromisesSwift"),
 		PodSpec.Create ("leveldb-library",             "1.22.6", frameworkSource: FrameworkSource.Pods, frameworkName: "leveldb"),
@@ -197,7 +196,8 @@ void SetArtifactsPodSpecs ()
 	//	PodSpec.Create ("Firebase", "8.10.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
 	//};
 	FIREBASE_INSTALLATIONS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseInstallations", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseInstallations", "12.6.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseSessions",      "12.6.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_PERFORMANCE_MONITORING_ARTIFACT.PodSpecs = new [] {
 		PodSpec.Create ("FirebasePerformance", "12.6.0", frameworkSource: FrameworkSource.Pods)

--- a/components.cake
+++ b/components.cake
@@ -184,7 +184,6 @@ void SetArtifactsPodSpecs ()
 		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("FirebaseSessions",            "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("FirebaseSharedSwift",         "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("GoogleAppMeasurement",        "12.6.0"),
 		PodSpec.Create ("PromisesSwift",               "2.4.0",  frameworkSource: FrameworkSource.Pods, frameworkName: "Promises", targetName: "PromisesSwift"),
 		PodSpec.Create ("leveldb-library",             "1.22.6", frameworkSource: FrameworkSource.Pods, frameworkName: "leveldb"),
 	};

--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -93,11 +93,6 @@
       <SmartLink>True</SmartLink>
       <ForceLoad>True</ForceLoad>
     </NativeReference>
-    <NativeReference Include="..\..\..\externals\FirebaseSessions.xcframework">
-      <Kind>Framework</Kind>
-      <SmartLink>True</SmartLink>
-      <ForceLoad>True</ForceLoad>
-    </NativeReference>
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingCoreSource Include="Enums.cs" />

--- a/source/Firebase/Installations/Installations.csproj
+++ b/source/Firebase/Installations/Installations.csproj
@@ -46,6 +46,11 @@
       <ForceLoad>True</ForceLoad>
       <Frameworks>Security</Frameworks>
     </NativeReference>
+    <NativeReference Include="..\..\..\externals\FirebaseSessions.xcframework">
+      <Kind>Framework</Kind>
+      <SmartLink>True</SmartLink>
+      <ForceLoad>True</ForceLoad>
+    </NativeReference>
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingCoreSource Include="Enums.cs" />


### PR DESCRIPTION
## Summary

Moves `FirebaseSessions` out of the `Firebase.Core` artifact and into `Firebase.Installations`.

## Why

The real Firebase 12.6.0 runtime graph has `FirebaseSessions` depending on `FirebaseInstallations`. Carrying Sessions from Core hid that dependency direction and made Core ship a support framework it does not own.

## Impact

`Firebase.Core` no longer packages `FirebaseSessions.xcframework`. `Firebase.Installations` now packages it alongside `FirebaseInstallations.xcframework`, so existing Crashlytics and PerformanceMonitoring consumers continue to receive Sessions through their existing Installations dependency without adding a Core -> Installations package cycle or introducing a new package ID.

This PR is stacked on #137 because #137 is still open.

## Validation

- `git diff --check`
- `dotnet tool restore`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.Core,Firebase.Installations,Firebase.Crashlytics,Firebase.PerformanceMonitoring`
- Inspected packed resource zips: Core no longer contains `FirebaseSessions.xcframework`; Installations contains `FirebaseInstallations.xcframework` and `FirebaseSessions.xcframework`
- Re-ran an `otool -L` closure check for `FirebaseSessions` and confirmed Installations, Crashlytics, and PerformanceMonitoring package closures include both `FirebaseSessions` and `FirebaseInstallations`