### PR TITLE
[codex] Add Firebase NuGet READMEs

### DIFF
--- a/docs/Firebase/NuGet/ABTesting.md
+++ b/docs/Firebase/NuGet/ABTesting.md
@@ -1,0 +1,151 @@
+# AdamE.Firebase.iOS.ABTesting
+
+.NET bindings for Firebase A/B Testing on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase A/B Testing Apple SDK surface exposed in the `Firebase.ABTesting` namespace. It provides access to experiment payload coordination APIs such as `ExperimentController`, `LifecycleEvents`, and default experiment lifecycle event names.
+
+Use this package when you need:
+
+- Firebase A/B Testing experiment payload handling from C#
+- access to `ExperimentController.SharedInstance`
+- experiment lifecycle event names for activation, timeout, expiration, and clearing
+
+Most app code uses this package indirectly through Firebase feature packages such as Remote Config, In-App Messaging, or Performance Monitoring.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase A/B Testing documentation: https://firebase.google.com/docs/ab-testing/
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.ABTesting" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.ABTesting
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs. Direct use of A/B Testing payload APIs is uncommon in app code, but the binding exposes the native controller surface.
+
+```csharp
+using System;
+using Firebase.ABTesting;
+using Firebase.Core;
+using Foundation;
+
+App.Configure();
+
+var controller = ExperimentController.SharedInstance;
+var events = new LifecycleEvents
+{
+    SetExperimentEventName = DefaultLifecycleEventNames.SetExperiment,
+    ActivateExperimentEventName = DefaultLifecycleEventNames.ActivateExperiment,
+    ClearExperimentEventName = DefaultLifecycleEventNames.ClearExperiment,
+    TimeoutExperimentEventName = DefaultLifecycleEventNames.TimeoutExperiment,
+    ExpireExperimentEventName = DefaultLifecycleEventNames.ExpireExperiment,
+};
+
+controller.UpdateExperiments(
+    "remote-config",
+    events,
+    ExperimentPayloadExperimentOverflowPolicy.DiscardOldest,
+    0,
+    Array.Empty<NSData>(),
+    error =>
+    {
+        if (error is not null)
+        {
+            Console.WriteLine(error.LocalizedDescription);
+        }
+    });
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.RemoteConfig` - commonly uses A/B Testing experiment payloads.
+- `AdamE.Firebase.iOS.InAppMessaging` - commonly uses A/B Testing experiment payloads.
+- `AdamE.Firebase.iOS.PerformanceMonitoring` - package metadata references A/B Testing as a companion dependency.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.ABTesting`. API names closely mirror the native Firebase Apple SDK surface and expose Apple-native concepts such as `NSError`, `NSData`, and callback-based completion handlers.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/Analytics.md
+++ b/docs/Firebase/NuGet/Analytics.md
@@ -1,0 +1,134 @@
+# AdamE.Firebase.iOS.Analytics
+
+.NET bindings for Firebase Analytics on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Analytics Apple SDK surface exposed in the `Firebase.Analytics` namespace. It provides static `Analytics` APIs and event, parameter, user property, consent, and session constants for reporting app analytics data to Firebase.
+
+Use this package when you need:
+
+- analytics event logging with `Analytics.LogEvent`
+- user property and user ID reporting with `Analytics.SetUserProperty` and `Analytics.SetUserId`
+- analytics collection, consent, and session controls
+- access to the Firebase Analytics app instance ID
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase Analytics documentation: https://firebase.google.com/docs/analytics/ios/start
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.Analytics
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using System.Collections.Generic;
+using Firebase.Analytics;
+using Firebase.Core;
+
+App.Configure();
+
+Analytics.LogEvent(EventNamesConstants.SelectContent, new Dictionary<object, object>
+{
+    { ParameterNamesConstants.ContentType, "screen" },
+    { ParameterNamesConstants.ItemId, "home" },
+});
+
+Analytics.SetUserProperty("paid", "account_type");
+Analytics.SetUserId("user-123");
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.Analytics`. API names closely mirror the native Firebase Analytics SDK surface, including static APIs on `Analytics` and Apple-native data shapes such as `NSDictionary` for parameter dictionaries.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/AppCheck.md
+++ b/docs/Firebase/NuGet/AppCheck.md
@@ -1,0 +1,138 @@
+# AdamE.Firebase.iOS.AppCheck
+
+.NET bindings for Firebase App Check on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase App Check Apple SDK surface exposed in the `Firebase.AppCheck` namespace. It provides access to App Check token APIs, provider factories, debug provider support, DeviceCheck support, and App Attest provider types exposed by the native SDK.
+
+Use this package when you need:
+
+- App Check provider configuration before Firebase app initialization
+- App Check token retrieval through `AppCheck.SharedInstance`
+- debug, DeviceCheck, or App Attest provider binding access
+- App Check token auto-refresh controls
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase App Check documentation: https://firebase.google.com/docs/app-check/ios/overview
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.AppCheck
+```
+
+## Basic usage
+
+Set the App Check provider factory before calling `Firebase.Core.App.Configure()`.
+
+```csharp
+using System;
+using Firebase.AppCheck;
+using Firebase.Core;
+
+AppCheck.SetAppCheckProviderFactory(new AppCheckDebugProviderFactory());
+App.Configure();
+
+AppCheck.SharedInstance.TokenForcingRefresh(true, (token, error) =>
+{
+    if (error is not null)
+    {
+        Console.WriteLine(error.LocalizedDescription);
+        return;
+    }
+
+    Console.WriteLine(token?.ExpirationDate);
+});
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.AppCheck`. API names closely mirror the native Firebase App Check SDK surface and expose Apple-native concepts such as `NSError`, `NSDate`, and provider factory protocols.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+App Check support in this binding was added through a special effort by GitHub user Kapusch.
+
+If this App Check package is valuable in your app or organization, sponsorship helps support that work and continued maintenance.
+
+- GitHub Sponsors: https://github.com/sponsors/Kapusch

--- a/docs/Firebase/NuGet/AppDistribution.md
+++ b/docs/Firebase/NuGet/AppDistribution.md
@@ -1,0 +1,143 @@
+# AdamE.Firebase.iOS.AppDistribution
+
+.NET bindings for Firebase App Distribution on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase App Distribution Apple SDK surface exposed in the `Firebase.AppDistribution` namespace. It provides access to tester sign-in, tester sign-out, update checking, and release metadata APIs exposed by the native SDK.
+
+Use this package when you need:
+
+- in-app tester sign-in for Firebase App Distribution builds
+- update checking for distributed tester builds
+- release metadata such as display version, build version, release notes, and expiration state
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase App Distribution documentation: https://firebase.google.com/docs/app-distribution
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.AppDistribution" Version="8.10.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.AppDistribution
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+The current binding exposes `signInTesterWithCompletion:` as `SigInTester(...)` and declares a second `SigInTester(...)` overload for the native update-check selector.
+
+```csharp
+using System;
+using Firebase.Core;
+
+App.Configure();
+
+var appDistribution = Firebase.AppDistribution.AppDistribution.SharedInstance;
+
+if (!appDistribution.IsTesterSignedIn)
+{
+    appDistribution.SigInTester(error =>
+    {
+        if (error is not null)
+        {
+            Console.WriteLine(error.LocalizedDescription);
+            return;
+        }
+
+        Console.WriteLine(appDistribution.IsTesterSignedIn);
+    });
+}
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
+
+This package currently uses the `8.10` package line in this repository. Verify compatibility carefully before combining it with Firebase packages from a different MAJOR.MINOR package line.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.AppDistribution`. API names closely mirror the native Firebase App Distribution SDK surface, with the binding-specific `SigInTester(...)` overload naming noted above.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/Auth.md
+++ b/docs/Firebase/NuGet/Auth.md
@@ -1,0 +1,144 @@
+# AdamE.Firebase.iOS.Auth
+
+.NET bindings for Firebase Authentication on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Authentication Apple SDK surface exposed in the `Firebase.Auth` namespace. It provides access to `Auth`, `User`, credentials, auth state listeners, action code APIs, password and email-link flows, provider sign-in APIs, and emulator configuration methods.
+
+Use this package when you need:
+
+- sign-in, sign-up, and sign-out flows from C#
+- access to the current Firebase Auth user through `Auth.CurrentUser`
+- auth state or ID token change listeners
+- email/password, anonymous, custom token, credential, or provider-based sign-in APIs
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase Authentication documentation: https://firebase.google.com/docs/auth/ios/manage-users
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.Auth
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using System;
+using Firebase.Auth;
+using Firebase.Core;
+
+App.Configure();
+
+var auth = Auth.DefaultInstance;
+auth.SignInAnonymously((result, error) =>
+{
+    if (error is not null)
+    {
+        Console.WriteLine(error.LocalizedDescription);
+        return;
+    }
+
+    Console.WriteLine(result?.User?.Uid);
+});
+
+var listener = auth.AddAuthStateDidChangeListener((_, user) =>
+{
+    Console.WriteLine(user?.Email);
+});
+
+// Later, when the listener is no longer needed:
+auth.RemoveAuthStateDidChangeListener(listener);
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.Auth`. API names closely mirror the native Firebase Authentication SDK surface and expose Apple-native concepts such as `NSError`, `NSUrl`, `NSDictionary`, and callback-based completion handlers.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/CloudFirestore.md
+++ b/docs/Firebase/NuGet/CloudFirestore.md
@@ -1,0 +1,146 @@
+# AdamE.Firebase.iOS.CloudFirestore
+
+.NET bindings for Cloud Firestore on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Cloud Firestore Apple SDK surface exposed in the `Firebase.CloudFirestore` namespace. It provides access to `Firestore`, collections, documents, queries, listeners, field values, batch writes, transactions, aggregate queries, and Firestore settings.
+
+Use this package when you need:
+
+- document and collection access from C#
+- Firestore queries and snapshot listeners
+- document writes, updates, deletes, and batch writes
+- Firestore field values such as server timestamps and array operations
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Cloud Firestore documentation: https://firebase.google.com/docs/firestore/
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.CloudFirestore
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using System;
+using System.Collections.Generic;
+using Firebase.CloudFirestore;
+using Firebase.Core;
+
+App.Configure();
+
+var firestore = Firestore.SharedInstance;
+var document = firestore.GetCollection("notes").GetDocument("welcome");
+
+document.SetData(new Dictionary<object, object>
+{
+    { "title", "Hello from Firestore" },
+    { "updatedAt", FieldValue.ServerTimestamp },
+});
+
+document.GetDocument((snapshot, error) =>
+{
+    if (error is not null)
+    {
+        Console.WriteLine(error.LocalizedDescription);
+        return;
+    }
+
+    Console.WriteLine(snapshot?.Exists);
+});
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Auth` - commonly used when Firestore security rules depend on Firebase Authentication.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.CloudFirestore`. API names closely mirror the native Cloud Firestore SDK surface and expose Apple-native concepts such as `NSDictionary`, `NSError`, listeners, and callback-based completion handlers.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/CloudFunctions.md
+++ b/docs/Firebase/NuGet/CloudFunctions.md
@@ -1,0 +1,140 @@
+# AdamE.Firebase.iOS.CloudFunctions
+
+.NET bindings for Cloud Functions for Firebase on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Cloud Functions for Firebase Apple SDK surface exposed in the `Firebase.CloudFunctions` namespace. It provides access to `CloudFunctions`, callable HTTPS functions, callable results, region and custom domain selection, and emulator configuration.
+
+Use this package when you need:
+
+- callable Cloud Functions access from C#
+- callable function invocation with `HttpsCallable.Call`
+- region-specific or custom-domain function clients
+- local emulator configuration for callable functions
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Cloud Functions for Firebase documentation: https://firebase.google.com/docs/functions
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.CloudFunctions
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using System;
+using Firebase.CloudFunctions;
+using Firebase.Core;
+
+App.Configure();
+
+var functions = CloudFunctions.DefaultInstance;
+var callable = functions.HttpsCallable("helloWorld");
+callable.TimeoutInterval = 30;
+
+callable.Call((result, error) =>
+{
+    if (error is not null)
+    {
+        Console.WriteLine(error.LocalizedDescription);
+        return;
+    }
+
+    Console.WriteLine(result?.Data);
+});
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Auth` - commonly used when callable functions depend on Firebase Authentication context.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.CloudFunctions`. API names closely mirror the native Cloud Functions for Firebase SDK surface and expose Apple-native concepts such as `NSObject`, `NSError`, and callback-based completion handlers.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/CloudMessaging.md
+++ b/docs/Firebase/NuGet/CloudMessaging.md
@@ -1,0 +1,142 @@
+# AdamE.Firebase.iOS.CloudMessaging
+
+.NET bindings for Firebase Cloud Messaging on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Cloud Messaging Apple SDK surface exposed in the `Firebase.CloudMessaging` namespace. It provides access to `Messaging`, FCM token APIs, APNs token assignment, topic subscription APIs, message delivery metadata, and notification service extension helper APIs.
+
+Use this package when you need:
+
+- FCM registration token retrieval from C#
+- APNs token registration through `Messaging.SetApnsToken`
+- topic subscribe and unsubscribe operations
+- notification extension helper access for rich notification handling
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase Cloud Messaging documentation: https://firebase.google.com/docs/cloud-messaging/ios/client
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.CloudMessaging
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs. Follow the official Firebase and Apple documentation for APNs registration and notification permissions.
+
+```csharp
+using System;
+using Firebase.CloudMessaging;
+using Firebase.Core;
+
+App.Configure();
+
+var messaging = Messaging.SharedInstance;
+messaging.AutoInitEnabled = true;
+
+messaging.FetchToken((fcmToken, error) =>
+{
+    if (error is not null)
+    {
+        Console.WriteLine(error.LocalizedDescription);
+        return;
+    }
+
+    Console.WriteLine(fcmToken);
+});
+
+messaging.Subscribe("news");
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
+- `AdamE.Firebase.iOS.Analytics` - commonly used when Cloud Messaging analytics and notification engagement reporting are needed.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.CloudMessaging`. API names closely mirror the native Firebase Cloud Messaging SDK surface and expose Apple-native concepts such as `NSData`, `NSDictionary`, `NSError`, and notification extension types.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/Core.md
+++ b/docs/Firebase/NuGet/Core.md
@@ -1,0 +1,134 @@
+# AdamE.Firebase.iOS.Core
+
+.NET bindings for Firebase Core on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Core Apple SDK surface exposed in the `Firebase.Core` namespace. It provides Firebase app initialization, app lookup, options, logger configuration, data collection defaults, and timestamp types used by other Firebase packages.
+
+Use this package when you need:
+
+- Firebase app initialization with `App.Configure()`
+- access to `App.DefaultInstance` or named Firebase app instances
+- custom Firebase options with `Options`
+- shared Firebase types such as `Timestamp`
+
+This package is foundational and is commonly used alongside feature-specific Firebase packages.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.Core
+```
+
+## Basic usage
+
+For the default Firebase app, include your app's `GoogleService-Info.plist` in the application project and call `App.Configure()`.
+
+```csharp
+using System;
+using Firebase.Core;
+
+App.Configure();
+
+var app = App.DefaultInstance;
+if (app is not null)
+{
+    app.DataCollectionDefaultEnabled = true;
+    Console.WriteLine(app.Name);
+}
+
+Configuration.SharedInstance.SetLoggerLevel(LoggerLevel.Info);
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Analytics` - analytics event reporting.
+- `AdamE.Firebase.iOS.Auth` - authentication and user identity flows.
+- `AdamE.Firebase.iOS.CloudFirestore` - Cloud Firestore document and collection access.
+- `AdamE.Firebase.iOS.Storage` - Cloud Storage for Firebase file upload and download APIs.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.Core`. API names closely mirror the native Firebase Core SDK surface and expose Apple-native concepts such as `NSDictionary`, `NSDate`, app options, and callback-based completion handlers.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/Crashlytics.md
+++ b/docs/Firebase/NuGet/Crashlytics.md
@@ -1,0 +1,139 @@
+# AdamE.Firebase.iOS.Crashlytics
+
+.NET bindings for Firebase Crashlytics on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Crashlytics Apple SDK surface exposed in the `Firebase.Crashlytics` namespace. It provides access to `Crashlytics`, custom logs and keys, user IDs, non-fatal error recording, exception models, unsent report management, and crash state inspection.
+
+Use this package when you need:
+
+- Crashlytics logging from C# with `Crashlytics.Log`
+- user IDs and custom keys for crash reports
+- non-fatal `NSError` or `ExceptionModel` recording
+- unsent report checks, sending, or deletion
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase Crashlytics documentation: https://firebase.google.com/docs/crashlytics/get-started
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.Crashlytics
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using Firebase.Core;
+using Firebase.Crashlytics;
+using Foundation;
+
+App.Configure();
+
+var crashlytics = Crashlytics.SharedInstance;
+crashlytics.Log("Opened checkout");
+crashlytics.SetUserId("user-123");
+crashlytics.SetCustomValue(new NSString("checkout"), "screen");
+
+var exception = new ExceptionModel("HandledError", "Checkout validation failed")
+{
+    StackTrace = new[]
+    {
+        StackFrame.Create("ValidateCart", "CheckoutService.cs", 42),
+    },
+};
+crashlytics.RecordExceptionModel(exception);
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.Crashlytics`. API names closely mirror the native Firebase Crashlytics SDK surface and expose Apple-native concepts such as `NSError`, `NSDictionary`, `NSDate`, and native exception model types.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/Database.md
+++ b/docs/Firebase/NuGet/Database.md
@@ -1,0 +1,137 @@
+# AdamE.Firebase.iOS.Database
+
+.NET bindings for Firebase Realtime Database on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Realtime Database Apple SDK surface exposed in the `Firebase.Database` namespace. It provides access to `Database`, database references, queries, snapshots, server values, transactions, offline persistence controls, and emulator configuration.
+
+Use this package when you need:
+
+- Realtime Database references and child paths from C#
+- value listeners and single-event reads
+- writes, updates, deletes, and transactions
+- offline persistence and cache controls
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase Realtime Database documentation: https://firebase.google.com/docs/database/ios/start
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.Database" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.Database
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using System;
+using Firebase.Core;
+using Firebase.Database;
+using Foundation;
+
+App.Configure();
+
+var database = Database.DefaultInstance;
+database.PersistenceEnabled = true;
+
+var statusRef = database.GetRootReference().GetChild("status");
+statusRef.SetValue(new NSString("online"));
+
+statusRef.ObserveSingleEvent(DataEventType.Value, snapshot =>
+{
+    Console.WriteLine(snapshot.Exists);
+});
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Auth` - commonly used when Realtime Database security rules depend on Firebase Authentication.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.Database`. API names closely mirror the native Firebase Realtime Database SDK surface and expose Apple-native concepts such as `NSObject`, `NSDictionary`, `NSError`, and callback-based listeners.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/InAppMessaging.md
+++ b/docs/Firebase/NuGet/InAppMessaging.md
@@ -1,0 +1,132 @@
+# AdamE.Firebase.iOS.InAppMessaging
+
+.NET bindings for Firebase In-App Messaging on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase In-App Messaging Apple SDK surface exposed in the `Firebase.InAppMessaging` namespace. It provides access to message display suppression, automatic data collection, custom trigger events, display delegates, display component protocols, and message model types for banner, card, modal, and image-only messages.
+
+Use this package when you need:
+
+- Firebase In-App Messaging campaign display control from C#
+- custom trigger events with `InAppMessaging.TriggerEvent`
+- display delegate callbacks for impressions, clicks, dismissals, and display errors
+- custom message display component integration
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase In-App Messaging documentation: https://firebase.google.com/docs/in-app-messaging
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.InAppMessaging" Version="8.10.0.3" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.InAppMessaging
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using Firebase.Core;
+
+App.Configure();
+
+var inAppMessaging = Firebase.InAppMessaging.InAppMessaging.SharedInstance;
+inAppMessaging.AutomaticDataCollectionEnabled = true;
+inAppMessaging.MessageDisplaySuppressed = false;
+inAppMessaging.TriggerEvent("purchase_complete");
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
+- `AdamE.Firebase.iOS.ABTesting` - package metadata references Firebase A/B Testing for campaign experiment handling.
+- `AdamE.Firebase.iOS.Analytics` - commonly used with In-App Messaging campaign triggers and measurement.
+
+This package currently uses the `8.10` package line in this repository. Verify compatibility carefully before combining it with Firebase packages from a different MAJOR.MINOR package line.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.InAppMessaging`. API names closely mirror the native Firebase In-App Messaging SDK surface and expose Apple-native concepts such as `NSObject`, `NSDictionary`, `NSError`, `NSUrl`, and UIKit display model types.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/Installations.md
+++ b/docs/Firebase/NuGet/Installations.md
@@ -1,0 +1,142 @@
+# AdamE.Firebase.iOS.Installations
+
+.NET bindings for Firebase Installations on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Installations Apple SDK surface exposed in the `Firebase.Installations` namespace. It provides access to Firebase installation IDs, installation auth tokens, installation deletion, per-app installations, and the installation ID change notification metadata exposed by the native SDK.
+
+Use this package when you need:
+
+- Firebase installation ID retrieval from C#
+- Firebase Installations auth token retrieval
+- installation deletion for reset or privacy workflows
+- direct access to the Firebase Installations native API surface
+
+Many Firebase feature packages reference Installations as an underlying dependency. Most app code only uses this package directly for installation identity or token workflows.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.Installations" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.Installations
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using System;
+using Firebase.Core;
+using Firebase.Installations;
+
+App.Configure();
+
+var installations = Installations.DefaultInstance;
+
+installations.GetInstallationId((identifier, error) =>
+{
+    if (error is not null)
+    {
+        Console.WriteLine(error.LocalizedDescription);
+        return;
+    }
+
+    Console.WriteLine(identifier);
+});
+
+installations.GetAuthToken(false, (tokenResult, error) =>
+{
+    Console.WriteLine(tokenResult?.ExpirationDate);
+});
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Analytics`, `AdamE.Firebase.iOS.CloudMessaging`, `AdamE.Firebase.iOS.Crashlytics`, and other feature packages - package metadata commonly references Firebase Installations for underlying Firebase identity support.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.Installations`. API names closely mirror the native Firebase Installations SDK surface and expose Apple-native concepts such as `NSError`, `NSDate`, and notification metadata.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/PerformanceMonitoring.md
+++ b/docs/Firebase/NuGet/PerformanceMonitoring.md
@@ -1,0 +1,139 @@
+# AdamE.Firebase.iOS.PerformanceMonitoring
+
+.NET bindings for Firebase Performance Monitoring on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Performance Monitoring Apple SDK surface exposed in the `Firebase.PerformanceMonitoring` namespace. It provides access to `Performance`, custom traces, trace metrics, HTTP metrics, attributes, data collection controls, and instrumentation controls.
+
+Use this package when you need:
+
+- custom performance traces from C#
+- trace metrics with `Trace.IncrementMetric` or `Trace.SetIntValue`
+- HTTP request metrics with `HttpMetric`
+- Performance Monitoring data collection and instrumentation toggles
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase Performance Monitoring documentation: https://firebase.google.com/docs/perf-mon/get-started-ios
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.PerformanceMonitoring" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.PerformanceMonitoring
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using Firebase.Core;
+using Firebase.PerformanceMonitoring;
+using Foundation;
+
+App.Configure();
+
+var trace = Performance.StartTrace("load_home");
+if (trace is not null)
+{
+    trace.IncrementMetric("items_loaded", 1);
+    trace.Stop();
+}
+
+var metric = new HttpMetric(new NSUrl("https://example.com/api"), HttpMethod.Get);
+metric.Start();
+metric.ResponseCode = 200;
+metric.ResponseContentType = "application/json";
+metric.Stop();
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
+- `AdamE.Firebase.iOS.ABTesting` and `AdamE.Firebase.iOS.RemoteConfig` - package metadata references these Firebase packages as companion dependencies.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.PerformanceMonitoring`. API names closely mirror the native Firebase Performance Monitoring SDK surface and expose Apple-native concepts such as `NSUrl`, attributes, and explicit start/stop tracing.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/RemoteConfig.md
+++ b/docs/Firebase/NuGet/RemoteConfig.md
@@ -1,0 +1,144 @@
+# AdamE.Firebase.iOS.RemoteConfig
+
+.NET bindings for Firebase Remote Config on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Firebase Remote Config Apple SDK surface exposed in the `Firebase.RemoteConfig` namespace. It provides access to `RemoteConfig`, fetch and activation APIs, default values, config values, config settings, real-time update listeners, and custom signals.
+
+Use this package when you need:
+
+- Remote Config fetch and activation from C#
+- default config values and typed config value access
+- real-time config update listeners
+- Remote Config settings such as fetch timeout and minimum fetch interval
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Firebase Remote Config documentation: https://firebase.google.com/docs/remote-config/use-config-ios
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.RemoteConfig
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using System;
+using System.Collections.Generic;
+using Firebase.Core;
+using Firebase.RemoteConfig;
+
+App.Configure();
+
+var remoteConfig = RemoteConfig.SharedInstance;
+remoteConfig.SetDefaults(new Dictionary<object, object>
+{
+    { "welcome_message", "Hello" },
+});
+
+remoteConfig.FetchAndActivate((status, error) =>
+{
+    if (error is not null)
+    {
+        Console.WriteLine(error.LocalizedDescription);
+        return;
+    }
+
+    Console.WriteLine(remoteConfig.GetConfigValue("welcome_message").NSStringValue);
+});
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
+- `AdamE.Firebase.iOS.ABTesting` - package metadata references Firebase A/B Testing for experiment payload handling.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.RemoteConfig`. API names closely mirror the native Firebase Remote Config SDK surface and expose Apple-native concepts such as `NSDictionary`, `NSError`, `NSDate`, `NSSet`, and callback-based completion handlers.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/docs/Firebase/NuGet/Storage.md
+++ b/docs/Firebase/NuGet/Storage.md
@@ -1,0 +1,145 @@
+# AdamE.Firebase.iOS.Storage
+
+.NET bindings for Cloud Storage for Firebase on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+
+## What this package provides
+
+This package binds the Cloud Storage for Firebase Apple SDK surface exposed in the `Firebase.Storage` namespace. It provides access to `Storage`, storage references, uploads, downloads, metadata, listing, task observation, retry controls, and emulator configuration.
+
+Use this package when you need:
+
+- file or data uploads to Cloud Storage for Firebase
+- file downloads, download URLs, metadata reads, and metadata updates
+- storage reference navigation by path or URL
+- upload and download task observation and management
+
+Most apps using this package also reference `AdamE.Firebase.iOS.Core` for Firebase app initialization.
+
+## Official Firebase documentation comes first
+
+These packages are **thin .NET bindings over the official Firebase Apple SDKs**.
+
+Use the official Firebase documentation as the starting point for:
+
+- Firebase configuration and platform setup
+- feature usage and behavioral guidance
+- troubleshooting and best practices
+
+These bindings primarily:
+
+- expose the native Firebase Apple SDK APIs to .NET through C#
+- deliver the packaged native Firebase SDK artifacts through NuGet
+
+- Firebase documentation: https://firebase.google.com/docs
+- Firebase Apple platform setup: https://firebase.google.com/docs/ios/setup
+- Cloud Storage for Firebase documentation: https://firebase.google.com/docs/storage/ios/start
+
+## Supported target frameworks
+
+This package is intended for Apple platform TFMs such as:
+
+- `net9.0-ios`
+- `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
+
+When multi-targeting, condition the package reference so it only restores for Apple targets.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+  <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="12.6.0" />
+</ItemGroup>
+```
+
+## Installation
+
+```sh
+dotnet add package AdamE.Firebase.iOS.Storage
+```
+
+## Basic usage
+
+This package does not itself perform Firebase app initialization; call `Firebase.Core.App.Configure()` from the app before using Firebase feature APIs.
+
+```csharp
+using System;
+using Firebase.Core;
+using Firebase.Storage;
+using Foundation;
+
+App.Configure();
+
+var uploadData = NSData.FromString("hello", NSStringEncoding.UTF8);
+var storage = Storage.DefaultInstance;
+var reference = storage.GetReferenceFromPath("uploads/profile.jpg");
+var metadata = new StorageMetadata { ContentType = "image/jpeg" };
+
+reference.PutData(uploadData, metadata, (uploadedMetadata, error) =>
+{
+    if (error is not null)
+    {
+        Console.WriteLine(error.LocalizedDescription);
+        return;
+    }
+
+    reference.GetDownloadUrl((url, downloadError) =>
+    {
+        Console.WriteLine(url);
+    });
+});
+```
+
+## Common companion packages
+
+- `AdamE.Firebase.iOS.Core` - Firebase app initialization.
+- `AdamE.Firebase.iOS.Auth` - commonly used when Cloud Storage security rules depend on Firebase Authentication.
+
+## Firebase app configuration
+
+Firebase apps commonly require app-specific configuration from your own Firebase project, such as `GoogleService-Info.plist`.
+
+Keep app-specific Firebase configuration in the application project or sample app, not in reusable library projects.
+
+If the official Firebase docs for this feature require additional setup, follow those docs first.
+
+## Package versioning rules (important)
+
+Because Firebase Apple SDKs are packaged as native xcframeworks and distributed here through NuGet, consumers should explicitly pin package versions.
+
+Due to packaging differences between CocoaPods and NuGet, it is highly recommended that applications follow these rules:
+
+1. Keep the MAJOR.MINOR version aligned across all Firebase packages in the app, for example `12.6.*.*`.
+2. Then use the latest available PATCH.REVISION for each individual package.
+
+Example:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+</ItemGroup>
+```
+
+Avoid mixing mismatched Firebase package lines such as `12.6.x.x` with `12.5.x.x`, or `12.x.x.x` with `11.x.x.x`. Doing so can lead to native dependency conflicts, duplicate symbols, runtime failures, or other undefined behavior.
+
+## Notes on native dependency conflicts
+
+Google and Firebase Apple SDKs share native dependencies. Avoid mixing multiple unrelated binding packages that embed overlapping Google/Firebase native SDK binaries in the same app unless you are certain they are compatible.
+
+## API surface notes
+
+The public namespace is `Firebase.Storage`. API names closely mirror the native Cloud Storage for Firebase SDK surface and expose Apple-native concepts such as `NSData`, `NSUrl`, `NSError`, metadata objects, and observable tasks.
+
+## Repository / support
+
+- Repository: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents
+- Issues: https://github.com/AdamEssenmacher/GoogleApisForiOSComponents/issues
+
+## Support the project
+
+Keeping Firebase Apple bindings current for .NET requires ongoing work across SDK updates, native dependency changes, and API surface maintenance.
+
+If this package is valuable in your app or organization, sponsorship helps support continued maintenance and updates.
+
+- GitHub Sponsors: https://github.com/sponsors/AdamEssenmacher

--- a/source/Firebase/ABTesting/ABTesting.csproj
+++ b/source/Firebase/ABTesting/ABTesting.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosabtesting_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/ABTesting.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosabtesting_128x128.png" Pack="True" PackagePath="firebaseiosabtesting_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/Analytics/Analytics.csproj
+++ b/source/Firebase/Analytics/Analytics.csproj
@@ -26,6 +26,7 @@
     <PackageIcon>firebaseiosanalytics_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -39,6 +40,7 @@
     <None Include="Analytics.targets" Pack="True" PackagePath="build/AdamE.Firebase.iOS.Analytics.targets" />
     <None Include="Analytics.targets" Pack="True" PackagePath="buildTransitive/AdamE.Firebase.iOS.Analytics.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/Analytics.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosanalytics_128x128.png" Pack="True" PackagePath="firebaseiosanalytics_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/AppCheck/AppCheck.csproj
+++ b/source/Firebase/AppCheck/AppCheck.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosappcheck_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -38,6 +39,7 @@
     <None Include="AppCheck.targets" Pack="True" PackagePath="build/AdamE.Firebase.iOS.AppCheck.targets" />
     <None Include="AppCheck.targets" Pack="True" PackagePath="buildTransitive/AdamE.Firebase.iOS.AppCheck.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/AppCheck.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosappcheck_128x128.png" Pack="True" PackagePath="firebaseiosappcheck_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/AppDistribution/AppDistribution.csproj
+++ b/source/Firebase/AppDistribution/AppDistribution.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosappdistribution_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>8.10.0</PackageVersion>
   </PropertyGroup>
@@ -36,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/AppDistribution.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosappdistribution_128x128.png" Pack="True" PackagePath="firebaseiosappdistribution_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/Auth/Auth.csproj
+++ b/source/Firebase/Auth/Auth.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosauth_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/Auth.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosauth_128x128.png" Pack="True" PackagePath="firebaseiosauth_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/CloudFirestore/CloudFirestore.csproj
+++ b/source/Firebase/CloudFirestore/CloudFirestore.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseioscloudfirestore_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/CloudFirestore.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseioscloudfirestore_128x128.png" Pack="True" PackagePath="firebaseioscloudfirestore_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/CloudFunctions/CloudFunctions.csproj
+++ b/source/Firebase/CloudFunctions/CloudFunctions.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseioscloudfunctions_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/CloudFunctions.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseioscloudfunctions_128x128.png" Pack="True" PackagePath="firebaseioscloudfunctions_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/CloudMessaging/CloudMessaging.csproj
+++ b/source/Firebase/CloudMessaging/CloudMessaging.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseioscloudmessaging_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/CloudMessaging.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseioscloudmessaging_128x128.png" Pack="True" PackagePath="firebaseioscloudmessaging_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseioscore_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -39,6 +40,7 @@
     <None Include="Core.targets" Pack="True" PackagePath="buildTransitive/AdamE.Firebase.iOS.Core.targets" />
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/Core.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseioscore_128x128.png" Pack="True" PackagePath="firebaseioscore_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/Crashlytics/Crashlytics.csproj
+++ b/source/Firebase/Crashlytics/Crashlytics.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseioscrashlytics_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -41,6 +42,7 @@
     <None Include="Crashlytics.props" Pack="True" PackagePath="buildTransitive/AdamE.Firebase.iOS.Crashlytics.props" />
     <None Include="readme.txt" Pack="True" PackagePath="readme.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/Crashlytics.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseioscrashlytics_128x128.png" Pack="True" PackagePath="firebaseioscrashlytics_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/Database/Database.csproj
+++ b/source/Firebase/Database/Database.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosdatabase_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/Database.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosdatabase_128x128.png" Pack="True" PackagePath="firebaseiosdatabase_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/InAppMessaging/InAppMessaging.csproj
+++ b/source/Firebase/InAppMessaging/InAppMessaging.csproj
@@ -24,6 +24,7 @@
     <PackageIcon>firebaseiosinappmessaging_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>8.10.0.3</PackageVersion>
   </PropertyGroup>
@@ -36,6 +37,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/InAppMessaging.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosinappmessaging_128x128.png" Pack="True" PackagePath="firebaseiosinappmessaging_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/Installations/Installations.csproj
+++ b/source/Firebase/Installations/Installations.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosinstallations_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/Installations.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosinstallations_128x128.png" Pack="True" PackagePath="firebaseiosinstallations_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
+++ b/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosperformancemonitoring_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -36,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/PerformanceMonitoring.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosperformancemonitoring_128x128.png" Pack="True" PackagePath="firebaseiosperformancemonitoring_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/RemoteConfig/RemoteConfig.csproj
+++ b/source/Firebase/RemoteConfig/RemoteConfig.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosremoteconfig_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -37,6 +38,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/RemoteConfig.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosremoteconfig_128x128.png" Pack="True" PackagePath="firebaseiosremoteconfig_128x128.png" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Firebase/Storage/Storage.csproj
+++ b/source/Firebase/Storage/Storage.csproj
@@ -25,6 +25,7 @@
     <PackageIcon>firebaseiosstorage_128x128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
@@ -34,6 +35,7 @@
   <ItemGroup>
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
+    <None Include="../../../docs/Firebase/NuGet/Storage.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosstorage_128x128.png" Pack="True" PackagePath="firebaseiosstorage_128x128.png" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add package-specific NuGet README files for all 16 Firebase source packages under `docs/Firebase/NuGet/`.
- Wire each `source/Firebase/*/*.csproj` to publish its matching README as `NUGET_README.md` via `PackageReadmeFile` and packed `None` metadata.
- Include the requested AppCheck note crediting Kapusch's special effort and linking to `https://github.com/sponsors/Kapusch` instead of the maintainer sponsorship link.

## Notes
- No runtime API or assembly surface changes.
- READMEs frame these packages as thin .NET bindings over the official Firebase Apple SDKs, point consumers to official Firebase docs first, and include Firebase package version alignment guidance.

## Validation
- `rg --files-without-match "PackageReadmeFile" source/Firebase -g '*.csproj'` produced no output.
- `rg -n "docs/Firebase/NuGet|PackagePath=\"NUGET_README.md\"|PackageReadmeFile" source/Firebase -g '*.csproj'` confirmed all 16 Firebase projects are wired.
- Verified all 16 README files include the required thin-binding/docs-first/versioning/support sections.
- `git diff --check`
- `dotnet tool restore`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.Core`
- Verified `output/AdamE.Firebase.iOS.Core.12.6.0.nupkg` includes `NUGET_README.md` and the nuspec contains `<readme>NUGET_README.md</readme>`.