### PR TITLE
Add Firestore cache settings protocol bindings

### DIFF
--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -837,27 +837,43 @@ namespace Firebase.CloudFirestore
 
 		// @property(nonatomic, strong) id<FIRLocalCacheSettings, NSObject> _Nonnull cacheSettings;
 		[Export ("cacheSettings", ArgumentSemantic.Strong)]
-		NSObject CacheSettings { get; set; }
+		ILocalCacheSettings CacheSettings { get; set; }
+	}
+
+	interface ILocalCacheSettings { }
+
+	// @protocol FIRLocalCacheSettings
+	[Protocol (Name = "FIRLocalCacheSettings")]
+	interface LocalCacheSettings
+	{
 	}
 
 	// @interface FIRPersistentCacheSettings : NSObject <NSCopying, FIRLocalCacheSettings>
 	[BaseType (typeof (NSObject), Name = "FIRPersistentCacheSettings")]
-	interface PersistentCacheSettings : INSCopying
+	interface PersistentCacheSettings : INSCopying, LocalCacheSettings
 	{
 		// - (instancetype _Nonnull)initWithSizeBytes:(NSNumber * _Nonnull)size;
 		[Export ("initWithSizeBytes:")]
 		NativeHandle Constructor (NSNumber size);
 	}
 
+	interface IMemoryGarbageCollectorSettings { }
+
+	// @protocol FIRMemoryGarbageCollectorSettings
+	[Protocol (Name = "FIRMemoryGarbageCollectorSettings")]
+	interface MemoryGarbageCollectorSettings
+	{
+	}
+
 	// @interface FIRMemoryEagerGCSettings : NSObject <NSCopying, FIRMemoryGarbageCollectorSettings>
 	[BaseType (typeof (NSObject), Name = "FIRMemoryEagerGCSettings")]
-	interface MemoryEagerGCSettings : INSCopying
+	interface MemoryEagerGCSettings : INSCopying, MemoryGarbageCollectorSettings
 	{
 	}
 
 	// @interface FIRMemoryLRUGCSettings : NSObject <NSCopying, FIRMemoryGarbageCollectorSettings>
 	[BaseType (typeof (NSObject), Name = "FIRMemoryLRUGCSettings")]
-	interface MemoryLRUGCSettings : INSCopying
+	interface MemoryLRUGCSettings : INSCopying, MemoryGarbageCollectorSettings
 	{
 		// - (instancetype _Nonnull)initWithSizeBytes:(NSNumber * _Nonnull)size;
 		[Export ("initWithSizeBytes:")]
@@ -866,11 +882,11 @@ namespace Firebase.CloudFirestore
 
 	// @interface FIRMemoryCacheSettings : NSObject <NSCopying, FIRLocalCacheSettings>
 	[BaseType (typeof (NSObject), Name = "FIRMemoryCacheSettings")]
-	interface MemoryCacheSettings : INSCopying
+	interface MemoryCacheSettings : INSCopying, LocalCacheSettings
 	{
 		// - (instancetype _Nonnull)initWithGarbageCollectorSettings:(id<FIRMemoryGarbageCollectorSettings, NSObject> _Nonnull)settings;
 		[Export ("initWithGarbageCollectorSettings:")]
-		NativeHandle Constructor (NSObject settings);
+		NativeHandle Constructor (IMemoryGarbageCollectorSettings settings);
 	}
 
 	// @interface FIRTransactionOptions : NSObject <NSCopying>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -2454,11 +2454,11 @@ static partial class FirebaseRuntimeDriftCases
         var cacheSettingsProperty = typeof(FirestoreSettings).GetProperty(
             nameof(FirestoreSettings.CacheSettings),
             BindingFlags.Instance | BindingFlags.Public);
-        if (cacheSettingsProperty?.PropertyType != typeof(NSObject))
+        if (cacheSettingsProperty?.PropertyType != typeof(ILocalCacheSettings))
         {
             throw new InvalidOperationException(
                 $"Expected managed API '{typeof(FirestoreSettings).FullName}.{nameof(FirestoreSettings.CacheSettings)}' " +
-                $"to return '{typeof(NSObject).FullName}' for selector '{cacheSettingsSelector}', " +
+                $"to return '{typeof(ILocalCacheSettings).FullName}' for selector '{cacheSettingsSelector}', " +
                 $"observed '{cacheSettingsProperty?.PropertyType.FullName ?? "<missing>"}'.");
         }
 
@@ -2479,7 +2479,7 @@ static partial class FirebaseRuntimeDriftCases
         RequireConstructor(typeof(MemoryLRUGCSettings), Type.EmptyTypes, "init");
         RequireConstructor(typeof(MemoryLRUGCSettings), new[] { typeof(NSNumber) }, "initWithSizeBytes:");
         RequireConstructor(typeof(MemoryCacheSettings), Type.EmptyTypes, "init");
-        RequireConstructor(typeof(MemoryCacheSettings), new[] { typeof(NSObject) }, "initWithGarbageCollectorSettings:");
+        RequireConstructor(typeof(MemoryCacheSettings), new[] { typeof(IMemoryGarbageCollectorSettings) }, "initWithGarbageCollectorSettings:");
         RequireVoidMethod(typeof(PersistentCacheIndexManager), nameof(PersistentCacheIndexManager.EnableIndexAutoCreation), enableIndexAutoCreationSelector);
         RequireVoidMethod(typeof(PersistentCacheIndexManager), nameof(PersistentCacheIndexManager.DisableIndexAutoCreation), disableIndexAutoCreationSelector);
         RequireVoidMethod(typeof(PersistentCacheIndexManager), nameof(PersistentCacheIndexManager.DeleteAllIndexes), deleteAllIndexesSelector);
@@ -2616,7 +2616,13 @@ static partial class FirebaseRuntimeDriftCases
             var cacheSettings = settings.CacheSettings
                 ?? throw new InvalidOperationException($"FirestoreSettings.CacheSettings returned null after assigning {assignedRuntimeTypeName}.");
 
-            return cacheSettings.GetType().FullName ?? assignedRuntimeTypeName;
+            if (cacheSettings is not NSObject nativeCacheSettings)
+            {
+                throw new InvalidOperationException(
+                    $"FirestoreSettings.CacheSettings returned '{cacheSettings.GetType().FullName}', which does not expose an NSObject native handle.");
+            }
+
+            return nativeCacheSettings.GetType().FullName ?? assignedRuntimeTypeName;
         }
     }
 #endif


### PR DESCRIPTION
## Summary
- Add the Firestore cache settings protocol bindings from `FIRLocalCacheSettings.h`.
- Type `FirestoreSettings.CacheSettings` as `ILocalCacheSettings` instead of raw `NSObject`.
- Type `MemoryCacheSettings`'s `initWithGarbageCollectorSettings:` constructor as `IMemoryGarbageCollectorSettings` and mark the concrete cache/GC settings classes as conforming to the native protocols.
- Update the existing `cloudfirestore-cache-settings` runtime drift case to assert the protocol-shaped managed surface and exercise the cache settings selectors.

## Header Evidence
- `externals/FirebaseFirestoreInternal.xcframework/ios-arm64_x86_64-simulator/FirebaseFirestoreInternal.framework/Headers/FIRLocalCacheSettings.h` declares `@protocol FIRLocalCacheSettings` and `@protocol FIRMemoryGarbageCollectorSettings`.
- The same header declares `FIRPersistentCacheSettings` and `FIRMemoryCacheSettings` as `FIRLocalCacheSettings`, and `FIRMemoryEagerGCSettings` / `FIRMemoryLRUGCSettings` as `FIRMemoryGarbageCollectorSettings`.
- The same header declares `initWithGarbageCollectorSettings:(id<FIRMemoryGarbageCollectorSettings, NSObject>)settings`.

## Validation
- `dotnet tool restore` passed.
- `dotnet build source/Firebase/CloudFirestore/CloudFirestore.csproj -c Release --no-restore` passed with existing nullable/package resolution warnings only.
- Targeted runtime validation passed against a project-reference build of the edited CloudFirestore binding: `RuntimeDrift:cloudfirestore-cache-settings` exercised `cacheSettings`, `setCacheSettings:`, `persistentCacheIndexManager`, `enableIndexAutoCreation`, `disableIndexAutoCreation`, and `deleteAllIndexes` without `ObjCRuntime.ObjCException` or marshaling failure.
- `git diff --check` passed.

## Notes
- I attempted the full `dotnet-cake --target=nuget --names="Firebase.CloudFirestore"` package path as well, but this Firestore slice hit local native build/tooling issues during the long Mac Catalyst/native packaging path rather than a binding compiler error. The managed multi-target binding build and targeted simulator runtime case both passed using the edited binding project.