### PR TITLE
Fix AppCheck error code packaging

### DIFF
--- a/source/Firebase/AppCheck/AppCheck.csproj
+++ b/source/Firebase/AppCheck/AppCheck.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
-    <ObjcBindingApiDefinition Include="Enums.cs" />
+    <ObjcBindingCoreSource Include="Enums.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" PrivateAssets="None">


### PR DESCRIPTION
## Summary
- Move AppCheck `Enums.cs` to `ObjcBindingCoreSource` so `Firebase.AppCheck.ErrorCode` is compiled into the binding assembly.

## Header Evidence
- `externals/FirebaseAppCheck.xcframework/ios-arm64_x86_64-simulator/FirebaseAppCheck.framework/Headers/FIRAppCheckErrors.h` declares `FIRAppCheckErrorCode` as an `NS_ERROR_ENUM`.
- This is a native enum support type, not an Objective-C API definition surface.

## Validation
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.AppCheck"`
- `git diff --check`

## Notes
This is split from PR #142 so the coverage tooling PR stays tooling-only.