### PR TITLE
Bind Auth action code URL as initializer

### DIFF
--- a/source/Firebase/Auth/ApiDefinition.cs
+++ b/source/Firebase/Auth/ApiDefinition.cs
@@ -156,11 +156,11 @@ namespace Firebase.Auth
 		[Export ("languageCode")]
 		string LanguageCode { get; }
 
-		// +(instancetype _Nullable)actionCodeURLWithLink:(NSString * _Nonnull)link;
-		[Static]
+		// -(instancetype _Nullable)actionCodeURLWithLink:(NSString * _Nonnull)link OBJC_DESIGNATED_INITIALIZER;
+		[DesignatedInitializer]
 		[return: NullAllowed]
 		[Export ("actionCodeURLWithLink:")]
-		ActionCodeUrl Create (string link);
+		NativeHandle Constructor (string link);
 	}
 
 	// typedef void (^FIRCheckActionCodeCallBack)(FIRActionCodeInfo * _Nullable, NSError * _Nullable);


### PR DESCRIPTION
## Summary
- Bind `FIRActionCodeURL actionCodeURLWithLink:` as a designated initializer constructor instead of a static factory.

## Header Evidence
- `externals/FirebaseAuth.xcframework/ios-arm64_x86_64-simulator/FirebaseAuth.framework/Headers/FirebaseAuth-Swift.h` declares `- (nullable instancetype)actionCodeURLWithLink:(NSString * _Nonnull)link OBJC_DESIGNATED_INITIALIZER SWIFT_METHOD_FAMILY(init);`.
- The previous binding exposed a class/static selector shape that does not match the 12.6 header.

## Validation
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.Auth"`
- `git diff --check`

## Notes
This is split from PR #142 so the coverage tooling PR stays tooling-only.