### PR TITLE
Make Auth APNS token readonly

### DIFF
--- a/source/Firebase/Auth/ApiDefinition.cs
+++ b/source/Firebase/Auth/ApiDefinition.cs
@@ -237,9 +237,10 @@ namespace Firebase.Auth
 		[Export ("shareAuthStateAcrossDevices")]
 		bool ShareAuthStateAcrossDevices { get; set; }
 
+		// @property (nonatomic, readonly, copy) NSData * _Nullable APNSToken;
 		[NullAllowed]
-		[Export ("APNSToken", ArgumentSemantic.Strong)]
-		NSData ApnsToken { get; set; }
+		[Export ("APNSToken", ArgumentSemantic.Copy)]
+		NSData ApnsToken { get; }
 
 		// -(void)updateCurrentUser:(FIRUser * _Nonnull)user completion:(FIRUserUpdateCallback _Nullable)completion;
 		[Async]


### PR DESCRIPTION
## Summary
- Make `Auth.ApnsToken` readonly and use copy semantics to match the native property.

## Header Evidence
- `externals/FirebaseAuth.xcframework/ios-arm64_x86_64-simulator/FirebaseAuth.framework/Headers/FirebaseAuth-Swift.h` declares `@property (nonatomic, readonly, copy) NSData * _Nullable APNSToken;`.
- The writable API remains available through `setAPNSToken:type:` / `SetApnsToken`.

## Validation
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.Auth"`
- `git diff --check`

## Notes
This is split from PR #142 so the coverage tooling PR stays tooling-only.