### PR TITLE
Make Storage md5 hash readonly

### DIFF
--- a/source/Firebase/Storage/ApiDefinition.cs
+++ b/source/Firebase/Storage/ApiDefinition.cs
@@ -130,7 +130,7 @@ namespace Firebase.Storage
 		// @property(copy, nonatomic, nullable, readonly) NSString *md5Hash;
 		[NullAllowed]
 		[Export ("md5Hash")]
-		string Md5Hash { get; set; }
+		string Md5Hash { get; }
 
 		// @property (readonly) int64_t generation;
 		[Export ("generation")]


### PR DESCRIPTION
## Summary
- Make `StorageMetadata.Md5Hash` readonly to match Firebase Storage 12.6.

## Header Evidence
- `externals/FirebaseStorage.xcframework/ios-arm64_x86_64-simulator/FirebaseStorage.framework/Headers/FirebaseStorage-Swift.h` declares `@property (nonatomic, readonly, copy) NSString * _Nullable md5Hash;`.
- The previous setter would imply a `setMd5Hash:` selector that is not declared by the native framework.

## Validation
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.Storage"`
- `git diff --check`

## Notes
This is split from PR #142 so the coverage tooling PR stays tooling-only.