### PR TITLE
Remove stale Storage metadata reference binding

### DIFF
--- a/source/Firebase/Storage/ApiDefinition.cs
+++ b/source/Firebase/Storage/ApiDefinition.cs
@@ -169,11 +169,6 @@ namespace Firebase.Storage
 		[Export ("updated", ArgumentSemantic.Copy)]
 		NSDate Updated { get; }
 
-		// @property (readonly, nonatomic, strong) FIRStorageReference * _Nullable storageReference;
-		[NullAllowed]
-		[Export ("storageReference", ArgumentSemantic.Strong)]
-		StorageReference StorageReference { get; }
-
 		// -(instancetype _Nullable)initWithDictionary:(NSDictionary * _Nonnull)dictionary __attribute__((objc_designated_initializer));
 		[DesignatedInitializer]
 		[Export ("initWithDictionary:")]


### PR DESCRIPTION
## Summary
- Remove `StorageMetadata.StorageReference`, which is not present in the Firebase Storage 12.6 metadata header surface.

## Header Evidence
- `externals/FirebaseStorage.xcframework/ios-arm64_x86_64-simulator/FirebaseStorage.framework/Headers/FirebaseStorage-Swift.h` contains nearby `FIRStorageMetadata` properties such as `md5Hash`, `name`, `path`, and `updated`, but does not declare `storageReference`.
- Keeping the property would expose a selector that is not available from the current native framework.

## Validation
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.Storage"`
- `git diff --check`

## Notes
This is split from PR #142 so the coverage tooling PR stays tooling-only.