### PR TITLE
Clean up Firebase binding header comments

### DIFF
--- a/source/Firebase/Analytics/ApiDefinition.cs
+++ b/source/Firebase/Analytics/ApiDefinition.cs
@@ -105,7 +105,7 @@ namespace Firebase.Analytics
 		void HandleUserActivity (NSObject userActivity);
 
 		///
-		/// This method comes from a category (FIRAnalytics+Constent.h)
+		/// This method comes from a category (FIRAnalytics+Consent.h)
 		///
 
 		// + (void)setConsent:(NSDictionary<FIRConsentType, FIRConsentStatus> *)consentSettings;

--- a/source/Firebase/Auth/ApiDefinition.cs
+++ b/source/Firebase/Auth/ApiDefinition.cs
@@ -20,23 +20,22 @@ namespace Firebase.Auth
 		[Export ("handleCodeInApp")]
 		bool HandleCodeInApp { get; set; }
 
-		// @property (readonly, copy, nonatomic) NSString * _Nullable iOSBundleID;
-		// -(void)setIOSBundleID:(NSString * _Nonnull)iOSBundleID;
+		// @property (nonatomic, copy) NSString * _Nullable iOSBundleID;
 		[NullAllowed]
 		[Export ("iOSBundleID")]
 		string IOSBundleId { get; set; }
 
-		// @property (readonly, copy, nonatomic) NSString * _Nullable androidPackageName;
+		// @property (nonatomic, copy) NSString * _Nullable androidPackageName;
 		[NullAllowed]
 		[Export ("androidPackageName")]
 		string AndroidPackageName { get; }
 
-		// @property (readonly, copy, nonatomic) NSString * _Nullable androidMinimumVersion;
+		// @property (nonatomic, copy) NSString * _Nullable androidMinimumVersion;
 		[NullAllowed]
 		[Export ("androidMinimumVersion")]
 		string AndroidMinimumVersion { get; }
 
-		// @property (readonly, assign, nonatomic) BOOL androidInstallIfNotAvailable;
+		// @property (nonatomic) BOOL androidInstallIfNotAvailable;
 		[Export ("androidInstallIfNotAvailable")]
 		bool AndroidInstallIfNotAvailable { get; }
 
@@ -64,7 +63,7 @@ namespace Firebase.Auth
 		[Export ("username")]
 		string Username { get; }
 
-		// @property (readonly, getter = isNewUser, nonatomic) BOOL newUser;
+		// @property (nonatomic, readonly) BOOL isNewUser;
 		[Export ("isNewUser")]
 		bool IsNewUser { get; }
 	}
@@ -156,7 +155,7 @@ namespace Firebase.Auth
 		[Export ("languageCode")]
 		string LanguageCode { get; }
 
-		// -(instancetype _Nullable)actionCodeURLWithLink:(NSString * _Nonnull)link OBJC_DESIGNATED_INITIALIZER;
+		// - (nullable instancetype)actionCodeURLWithLink:(NSString * _Nonnull)link OBJC_DESIGNATED_INITIALIZER SWIFT_METHOD_FAMILY(init);
 		[DesignatedInitializer]
 		[return: NullAllowed]
 		[Export ("actionCodeURLWithLink:")]
@@ -409,7 +408,7 @@ namespace Firebase.Auth
 	// @interface FIRAuthSettings : NSObject
 	[BaseType (typeof (NSObject), Name = "FIRAuthSettings")]
 	interface AuthSettings {
-		// @property (getter = isAppVerificationDisabledForTesting, assign, nonatomic) BOOL appVerificationDisabledForTesting;
+		// @property (nonatomic) BOOL appVerificationDisabledForTesting;
 		[Export ("appVerificationDisabledForTesting")]
 		bool AppVerificationDisabledForTesting { [Bind ("isAppVerificationDisabledForTesting")] get; set; }
 	}
@@ -417,31 +416,31 @@ namespace Firebase.Auth
 	// @interface FIRAuthTokenResult : NSObject
 	[BaseType (typeof (NSObject), Name = "FIRAuthTokenResult")]
 	interface AuthTokenResult {
-		// @property (readonly, nonatomic) NSString * _Nonnull token;
+		// @property (nonatomic, copy) NSString * _Nonnull token;
 		[Export ("token")]
 		string Token { get; }
 
-		// @property (readonly, nonatomic) NSDate * _Nonnull expirationDate;
+		// @property (nonatomic, copy) NSDate * _Nonnull expirationDate;
 		[Export ("expirationDate")]
 		NSDate ExpirationDate { get; }
 
-		// @property (readonly, nonatomic) NSDate * _Nonnull authDate;
+		// @property (nonatomic, copy) NSDate * _Nonnull authDate;
 		[Export ("authDate")]
 		NSDate AuthDate { get; }
 
-		// @property (readonly, nonatomic) NSDate * _Nonnull issuedAtDate;
+		// @property (nonatomic, copy) NSDate * _Nonnull issuedAtDate;
 		[Export ("issuedAtDate")]
 		NSDate IssuedAtDate { get; }
 
-		// @property (readonly, nonatomic) NSString * _Nonnull signInProvider;
+		// @property (nonatomic, copy) NSString * _Nonnull signInProvider;
 		[Export ("signInProvider")]
 		string SignInProvider { get; }
 
-		// @property (readonly, nonatomic) NSString * _Nonnull signInSecondFactor;
+		// @property (nonatomic, copy) NSString * _Nonnull signInSecondFactor;
 		[Export ("signInSecondFactor")]
 		string SignInSecondFactor { get; }
 
-		// @property (readonly, nonatomic) NSDictionary<NSString *,id> * _Nonnull claims;
+		// @property (nonatomic, copy) NSDictionary<NSString *, id> * _Nonnull claims;
 		[Export ("claims")]
 		NSDictionary<NSString, NSObject> Claims { get; }
 	}
@@ -597,7 +596,7 @@ namespace Firebase.Auth
 		[Field ("FIRPhoneMultiFactorID", "__Internal")]
 		NSString PhoneMultiFactorId { get; }
 
-		// @property (readonly, nonatomic) NSArray<FIRMultiFactorInfo *> * _Nonnull enrolledFactors;
+		// @property (nonatomic, copy) NSArray<FIRMultiFactorInfo *> * _Nonnull enrolledFactors;
 		[Export ("enrolledFactors")]
 		MultiFactorInfo [] EnrolledFactors { get; }
 
@@ -622,7 +621,7 @@ namespace Firebase.Auth
 	[BaseType (typeof(NSObject), Name = "FIRMultiFactorAssertion")]
 	interface MultiFactorAssertion
 	{
-		// @property (readonly, nonatomic) NSString * _Nonnull factorID;
+		// @property (nonatomic, copy) NSString * _Nonnull factorID;
 		[Export ("factorID")]
 		string FactorId { get; }
 	}
@@ -821,7 +820,7 @@ namespace Firebase.Auth
 	[BaseType (typeof(MultiFactorInfo), Name = "FIRPhoneMultiFactorInfo")]
 	interface PhoneMultiFactorInfo
 	{
-		// @property (readonly, nonatomic) NSString * _Nonnull phoneNumber;
+		// @property (nonatomic, copy) NSString * _Nonnull phoneNumber;
 		[Export ("phoneNumber")]
 		string PhoneNumber { get; }
 	}
@@ -862,11 +861,11 @@ namespace Firebase.Auth
 	[BaseType (typeof (NSObject), Name = "FIRUser")]
 	interface User : UserInfo
 	{
-		// @property (readonly, getter = isAnonymous, nonatomic) BOOL anonymous;
+		// @property (nonatomic, readonly) BOOL isAnonymous;
 		[Export ("anonymous")]
 		bool IsAnonymous { [Bind ("isAnonymous")] get; }
 
-		// @property (readonly, getter = isEmailVerified, nonatomic) BOOL emailVerified;
+		// @property (nonatomic, readonly) BOOL isEmailVerified;
 		[Export ("emailVerified")]
 		bool IsEmailVerified { [Bind ("isEmailVerified")] get; }
 

--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -765,7 +765,7 @@ namespace Firebase.CloudFirestore
 		void GetQueryNamed (string name, Action<Query> completion);
 	}
 
-	// @interface FIRTimestamp : NSObject <NSCopying>
+	// @interface FIRLoadBundleTaskProgress : NSObject
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRLoadBundleTaskProgress")]
 	interface LoadBundleTaskProgress {
@@ -785,16 +785,16 @@ namespace Firebase.CloudFirestore
 		[Export ("totalBytes")]
 		nint TotalBytes { get; }
 
-		//@property(readonly, nonatomic) FIRLoadBundleTaskState state;
+		// @property(readonly, nonatomic) FIRLoadBundleTaskState state;
 		[Export ("state")]
 		LoadBundleTaskState State { get; }
 	}
 
-	// @interface FIRTimestamp : NSObject <NSCopying>
+	// @interface FIRLoadBundleTask : NSObject
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRLoadBundleTask")]
 	interface LoadBundleTask {
-		// - (FIRLoadBundleObserverHandle):(void (^)(FIRLoadBundleTaskProgress *progress))observer
+		// - (FIRLoadBundleObserverHandle)addObserver:(void (^)(FIRLoadBundleTaskProgress *progress))observer NS_SWIFT_NAME(addObserver(_:));
 		[Export ("addObserver:")]
 		nint AddObserver (Action<LoadBundleTaskProgress> observer);
 

--- a/source/Firebase/CloudFunctions/ApiDefinition.cs
+++ b/source/Firebase/CloudFunctions/ApiDefinition.cs
@@ -18,7 +18,7 @@ namespace Firebase.CloudFunctions
 		[Export("functions")]
 		CloudFunctions DefaultInstance { get; }
 
-		// + (FIRFunctions *)functionsForApp:(FIRAPP *)app;
+		// + (FIRFunctions *)functionsForApp:(FIRApp *)app;
 		[Static]
 		[Export("functionsForApp:")]
 		CloudFunctions From(App app);

--- a/source/Firebase/Core/ApiDefinition.cs
+++ b/source/Firebase/Core/ApiDefinition.cs
@@ -95,7 +95,7 @@ namespace Firebase.Core
 		[Export ("defaultOptions")]
 		Options DefaultInstance { get; }
 
-		// @property (readonly, copy, nonatomic) NSString * APIKey;
+		// @property(nonatomic, copy, nullable) NSString *APIKey NS_SWIFT_NAME(apiKey);
 		[NullAllowed]
 		[Export ("APIKey")]
 		string ApiKey { get; set; }
@@ -104,30 +104,30 @@ namespace Firebase.Core
 		[Export ("bundleID")]
 		string BundleId { get; set; }
 
-		// @property (readonly, copy, nonatomic) NSString * clientID;
+		// @property(nonatomic, copy, nullable) NSString *clientID;
 		[NullAllowed]
 		[Export ("clientID")]
 		string ClientId { get; set; }
 
-		// @property (readonly, copy, nonatomic) NSString * GCMSenderID;
+		// @property(nonatomic, copy) NSString *GCMSenderID NS_SWIFT_NAME(gcmSenderID);
 		[Export ("GCMSenderID")]
 		string GcmSenderId { get; set; }
 
-		// @property(nonatomic, readonly, copy) NSString *projectID;
+		// @property(nonatomic, copy, nullable) NSString *projectID;
 		[NullAllowed]
 		[Export ("projectID")]
 		string ProjectId { get; set; }
 
-		// @property (readonly, copy, nonatomic) NSString * googleAppID;
+		// @property(nonatomic, copy) NSString *googleAppID;
 		[Export ("googleAppID")]
 		string GoogleAppId { get; set; }
 
-		// @property (readonly, copy, nonatomic) NSString * databaseURL;
+		// @property(nonatomic, copy, nullable) NSString *databaseURL;
 		[NullAllowed]
 		[Export ("databaseURL")]
 		string DatabaseUrl { get; set; }
 
-		// @property (readonly, copy, nonatomic) NSString * storageBucket;
+		// @property(nonatomic, copy, nullable) NSString *storageBucket;
 		[NullAllowed]
 		[Export ("storageBucket")]
 		string StorageBucket { get; set; }

--- a/source/Firebase/RemoteConfig/ApiDefinition.cs
+++ b/source/Firebase/RemoteConfig/ApiDefinition.cs
@@ -54,7 +54,7 @@ namespace Firebase.RemoteConfig
 		[Export ("boolValue")]
 		bool BoolValue { get; }
 
-		// @property (readonly, nonatomic) id _Nullable JSONValue __attribute__((swift_name("jsonValue")));
+		// @property(nonatomic, readonly, nullable) id JSONValue NS_SWIFT_NAME(jsonValue);
 		[NullAllowed]
 		[Export ("JSONValue")]
 		NSObject JsonValue { get; }

--- a/source/Firebase/Storage/ApiDefinition.cs
+++ b/source/Firebase/Storage/ApiDefinition.cs
@@ -178,11 +178,11 @@ namespace Firebase.Storage
 		[Export ("dictionaryRepresentation")]
 		NSDictionary DictionaryRepresentation { get; }
 
-		// @property (readonly, getter = isFile) BOOL file;
+		// @property (nonatomic, readonly) BOOL isFile;
 		[Export ("isFile")]
 		bool IsFile { get; }
 
-		// @property (readonly, getter = isFolder) BOOL folder;
+		// @property (nonatomic, readonly) BOOL isFolder;
 		[Export ("isFolder")]
 		bool IsFolder { get; }
 	}


### PR DESCRIPTION
## Summary
- Updates generated Objective-C declaration comments in active Firebase binding definitions to match the Firebase 12.6 headers.
- Corrects stale Auth/Core/CloudFirestore/RemoteConfig/Storage declaration comments plus small typos in Analytics and CloudFunctions comments.
- Keeps the change documentation-only: no binding attributes, selectors, signatures, project files, or generated package metadata changed.

## Validation
- Compared suspicious generated comments against the 12.6 xcframework headers in `externals/`.
- Ran a class-aware header/comment scan for the cleaned drift categories; it reported zero remaining findings.
- Ran `git diff --check`.

## Notes
- This PR was created from a clean temporary worktree based on fresh `origin/main` so it excludes the unrelated dirty files currently present in the original working tree.