### PR TITLE
[codex] Add FirebaseDatabase icucore linker flag

### DIFF
--- a/source/Firebase/Database/Database.csproj
+++ b/source/Firebase/Database/Database.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <NativeReference Include="..\..\..\externals\FirebaseDatabase.xcframework">
       <Kind>Framework</Kind>
-      <LinkerFlags>-ObjC -lc++</LinkerFlags>
+      <LinkerFlags>-ObjC -lc++ -licucore</LinkerFlags>
       <Frameworks>CFNetwork Security SystemConfiguration</Frameworks>
       <SmartLink>True</SmartLink>
       <ForceLoad>True</ForceLoad>


### PR DESCRIPTION
## Summary
- Add `-licucore` to the `FirebaseDatabase.xcframework` NativeReference linker flags.

## Why
The FirebaseDatabase 12.6.0 podspec declares `icucore` alongside `c++`, and the real Firebase binary links `libicucore.A.dylib`. This keeps the binding metadata aligned with the upstream runtime dependency.

## Validation
- `git diff --check` in `/tmp/gafioc-db-icucore`