### PR TITLE
[codex] Add FirebaseAppCheck DeviceCheck weak framework

### DIFF
--- a/source/Firebase/AppCheck/AppCheck.csproj
+++ b/source/Firebase/AppCheck/AppCheck.csproj
@@ -47,6 +47,7 @@
       <Kind>Framework</Kind>
       <SmartLink>True</SmartLink>
       <ForceLoad>True</ForceLoad>
+      <WeakFrameworks>DeviceCheck</WeakFrameworks>
       <LinkerFlags>-ObjC</LinkerFlags>
     </NativeReference>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Add `DeviceCheck` as a weak framework on the `FirebaseAppCheck.xcframework` NativeReference.

## Why
The FirebaseAppCheck 12.6.0 podspec declares `DeviceCheck` as an iOS weak framework, and the real Firebase binary weak-links `DeviceCheck.framework`. This keeps the binding metadata aligned with the upstream runtime dependency.

## Validation
- `git diff --check` in `/tmp/gafioc-appcheck-devicecheck`