### PR TITLE
[codex] Add leveldb C++ linker flag

### DIFF
--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -54,6 +54,7 @@
       <Kind>Framework</Kind>
       <SmartLink>True</SmartLink>
       <ForceLoad>True</ForceLoad>
+      <LinkerFlags>-lc++</LinkerFlags>
     </NativeReference>
     <NativeReference Include="..\..\..\externals\FirebaseAppCheckInterop.xcframework">
       <Kind>Framework</Kind>


### PR DESCRIPTION
## Summary
- Add `-lc++` to the `leveldb.xcframework` NativeReference linker flags in Firebase Core.

## Why
The `leveldb-library` 1.22.6 podspec declares `c++`, and the real binary links `libc++.1.dylib`. This keeps the binding metadata aligned with the upstream dependency metadata.

## Validation
- `git diff --check` in `/tmp/gafioc-core-leveldb-cxx`