### PR TITLE
[codex] Add CloudFirestore UIKit and C++ linker metadata

### DIFF
--- a/source/Firebase/CloudFirestore/CloudFirestore.csproj
+++ b/source/Firebase/CloudFirestore/CloudFirestore.csproj
@@ -51,7 +51,7 @@
     </NativeReference>
     <NativeReference Include="..\..\..\externals\FirebaseFirestoreInternal.xcframework">
       <Kind>Framework</Kind>
-      <Frameworks>MobileCoreServices SystemConfiguration</Frameworks>
+      <Frameworks>MobileCoreServices SystemConfiguration UIKit</Frameworks>
       <SmartLink>True</SmartLink>
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-ObjC -lc++</LinkerFlags>
@@ -66,6 +66,7 @@
       <Kind>Framework</Kind>
       <SmartLink>True</SmartLink>
       <ForceLoad>True</ForceLoad>
+      <LinkerFlags>-lc++</LinkerFlags>
     </NativeReference>
     <NativeReference Include="..\..\..\externals\openssl_grpc.xcframework">
       <Kind>Framework</Kind>


### PR DESCRIPTION
## Summary
- Add `UIKit` to `FirebaseFirestoreInternal.xcframework` frameworks.
- Add `-lc++` to the `grpcpp.xcframework` NativeReference linker flags.

## Why
The FirebaseFirestoreInternal 12.6.0 podspec declares `UIKit`, and the real binary links UIKit. The `gRPC-C++` 1.69.0 podspec declares `c++`, matching the real `grpcpp` binary's `libc++` dependency. Per scope, this PR only updates `-lc++` and `UIKit` metadata for CloudFirestore.

## Validation
- `git diff --check` in `/tmp/gafioc-cloudfirestore-cxx-uikit`