### PR TITLE
[codex] Fix Firebase binding surface coverage false positives

### DIFF
--- a/scripts/FirebaseBindingAudit.Tests/BindingSurfaceCoverageBuilderTests.cs
+++ b/scripts/FirebaseBindingAudit.Tests/BindingSurfaceCoverageBuilderTests.cs
@@ -465,6 +465,53 @@ public sealed class BindingSurfaceCoverageBuilderTests
     }
 
     [Fact]
+    public void Build_DoesNotTreatApiDefinitionHelperExportsAsNativeClasses()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), $"firebase-binding-surface-builder-{Guid.NewGuid():N}");
+
+        try
+        {
+            var sourceDirectory = Path.Combine(repoRoot, "source", "Firebase", "Auth");
+            Directory.CreateDirectory(sourceDirectory);
+            File.WriteAllText(
+                Path.Combine(sourceDirectory, "ApiDefinition.cs"),
+                """
+                namespace Firebase.Auth;
+
+                public interface InstallationIdChangedEventArgs
+                {
+                    [Export("kFIRInstallationIDDidChangeNotificationAppNameKey")]
+                    string AppName { get; set; }
+                }
+                """);
+
+            var document = new BindingSurfaceCoverageBuilder(CreateConfiguration()).Build(
+                repoRoot,
+                CreateManifest(),
+                "Auth");
+
+            var surface = Assert.Single(
+                document.Targets.Single().Surfaces,
+                static surface => surface.MemberName == "AppName");
+
+            Assert.Equal("manual-property", surface.Kind);
+            Assert.Null(surface.ObjectiveCName);
+            Assert.Empty(surface.NativeSelectors);
+            Assert.Equal("Export", surface.BindingAttribute);
+            Assert.Equal("kFIRInstallationIDDidChangeNotificationAppNameKey", surface.BindingValue);
+            Assert.True(surface.HasGetter);
+            Assert.False(surface.HasSetter);
+        }
+        finally
+        {
+            if (Directory.Exists(repoRoot))
+            {
+                Directory.Delete(repoRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void Build_IncludesImplicitlyPublicInterfaceHelperMembers()
     {
         var repoRoot = Path.Combine(Path.GetTempPath(), $"firebase-binding-surface-builder-{Guid.NewGuid():N}");

--- a/scripts/FirebaseBindingAudit/BindingModel.cs
+++ b/scripts/FirebaseBindingAudit/BindingModel.cs
@@ -327,9 +327,8 @@ internal sealed class BindingSyntaxParser
             {
                 Kind = ToManualMemberKind(member.Kind),
                 ContainerKind = isStatic ? "static class" : containerKind,
-                ObjectiveCName = string.Equals(member.BindingAttribute, "Export", StringComparison.Ordinal) ? typeMatchKey : null,
                 HasGetter = member.HasGetter,
-                HasSetter = member.HasSetter
+                HasSetter = false
             });
         }
     }

--- a/scripts/FirebaseBindingAudit/BindingSurfaceCoverage.cs
+++ b/scripts/FirebaseBindingAudit/BindingSurfaceCoverage.cs
@@ -967,6 +967,11 @@ internal sealed class BindingSurfaceCoverageBuilder
         string? bindingAttribute,
         string? bindingValue)
     {
+        if (string.IsNullOrWhiteSpace(manualItem.ObjectiveCName))
+        {
+            return EmptySelectors;
+        }
+
         if (!string.Equals(bindingAttribute, "Export", StringComparison.Ordinal) ||
             string.IsNullOrWhiteSpace(bindingValue))
         {

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseBindingSurfaceCoverage.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseBindingSurfaceCoverage.cs
@@ -753,9 +753,25 @@ public static partial class FirebaseBindingSurfaceCoverage
 
             AddTypeNameCandidate(candidates, type.Name);
             AddTypeNameCandidate(candidates, type.FullName);
+            AddTypeNameSuffixCandidates(candidates, type.FullName);
         }
 
         return candidates;
+    }
+
+    static void AddTypeNameSuffixCandidates(List<string> candidates, string? typeName)
+    {
+        var normalizedTypeName = NormalizeTypeName(typeName);
+        if (string.IsNullOrWhiteSpace(normalizedTypeName))
+        {
+            return;
+        }
+
+        var parts = normalizedTypeName.Split('.');
+        for (var index = 1; index < parts.Length - 1; index++)
+        {
+            AddTypeNameCandidate(candidates, string.Join('.', parts[index..]));
+        }
     }
 
     static IEnumerable<string> CreateGenericTypeNameCandidates(Type genericDefinition)


### PR DESCRIPTION
## Summary
- Fixes Firebase binding surface coverage false positives from shorthand source type names such as `Core.App` vs reflected runtime names such as `Firebase.Core.App`.
- Stops ApiDefinition helper/event-args exports from being treated as Objective-C class surfaces in the generated coverage inventory.
- Adds regression coverage for notification event-args helper exports so they stay reflection-only instead of native-class probes.

## Root Cause
The exhaustive E2E coverage harness was stricter than the generated binding runtime shape in two places:
- Source inventory parameter names can use namespace shorthand while reflection reports fully qualified runtime type names.
- Notification event-args helper interfaces can contain `[Export]` metadata used by the binding generator, but they do not correspond to real Objective-C classes or writable runtime properties.

## Validation
- `dotnet test scripts/FirebaseBindingAudit.Tests/FirebaseBindingAudit.Tests.csproj --no-restore`
  - Passed: 50/50
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --binding-surface-target all`
  - Passed
  - Binding surface coverage: 1507 surfaces, 1507 exercised, 0 waived, 0 failed
- `git diff --check`
  - Passed

## Notes
Unrelated local changes were intentionally left out of this PR: `docs/firebase-runtime-failure-backlog.md` and `.github/workflows/firebase-e2e.yml`.