### PR TITLE
Restore Firebase InAppMessaging for 12.6.0

### DIFF
--- a/components.cake
+++ b/components.cake
@@ -8,7 +8,7 @@ Artifact FIREBASE_CLOUD_MESSAGING_ARTIFACT         = new Artifact ("Firebase.Clo
 Artifact FIREBASE_CORE_ARTIFACT                    = new Artifact ("Firebase.Core",                   "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Core");
 Artifact FIREBASE_CRASHLYTICS_ARTIFACT             = new Artifact ("Firebase.Crashlytics",            "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Crashlytics");
 Artifact FIREBASE_DATABASE_ARTIFACT                = new Artifact ("Firebase.Database",               "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Database");
-//Artifact FIREBASE_IN_APP_MESSAGING_ARTIFACT      = new Artifact ("Firebase.InAppMessaging",         "8.10.0.3", "15.0", ComponentGroup.Firebase, csprojName: "InAppMessaging");
+Artifact FIREBASE_IN_APP_MESSAGING_ARTIFACT        = new Artifact ("Firebase.InAppMessaging",         "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "InAppMessaging");
 Artifact FIREBASE_INSTALLATIONS_ARTIFACT           = new Artifact ("Firebase.Installations",          "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Installations");
 Artifact FIREBASE_PERFORMANCE_MONITORING_ARTIFACT  = new Artifact ("Firebase.PerformanceMonitoring",  "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "PerformanceMonitoring");
 Artifact FIREBASE_REMOTE_CONFIG_ARTIFACT           = new Artifact ("Firebase.RemoteConfig",           "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "RemoteConfig");
@@ -59,7 +59,7 @@ var ARTIFACTS = new Dictionary<string, Artifact> {
 	{ "Firebase.Core",                   FIREBASE_CORE_ARTIFACT },
 	{ "Firebase.Crashlytics",            FIREBASE_CRASHLYTICS_ARTIFACT },
 	{ "Firebase.Database",               FIREBASE_DATABASE_ARTIFACT },
-	//{ "Firebase.InAppMessaging",         FIREBASE_IN_APP_MESSAGING_ARTIFACT },
+	{ "Firebase.InAppMessaging",         FIREBASE_IN_APP_MESSAGING_ARTIFACT },
 	{ "Firebase.Installations",          FIREBASE_INSTALLATIONS_ARTIFACT },
 	{ "Firebase.PerformanceMonitoring",  FIREBASE_PERFORMANCE_MONITORING_ARTIFACT },
 	{ "Firebase.RemoteConfig",           FIREBASE_REMOTE_CONFIG_ARTIFACT },
@@ -109,7 +109,7 @@ void SetArtifactsDependencies ()
 	FIREBASE_CORE_ARTIFACT.Dependencies                    = new [] { GOOGLE_GOOGLE_DATA_TRANSPORT_ARTIFACT, GOOGLE_GOOGLE_UTILITIES_ARTIFACT, GOOGLE_NANOPB_ARTIFACT, GOOGLE_PROMISES_OBJC_ARTIFACT};
 	FIREBASE_CRASHLYTICS_ARTIFACT.Dependencies             = new [] { FIREBASE_CORE_ARTIFACT, FIREBASE_INSTALLATIONS_ARTIFACT };
 	FIREBASE_DATABASE_ARTIFACT.Dependencies                = new [] { FIREBASE_CORE_ARTIFACT, /* Needed for sample FIREBASE_AUTH_ARTIFACT */ };
-	//FIREBASE_IN_APP_MESSAGING_ARTIFACT.Dependencies        = new [] { FIREBASE_CORE_ARTIFACT, FIREBASE_INSTALLATIONS_ARTIFACT, FIREBASE_AB_TESTING_ARTIFACT };
+	FIREBASE_IN_APP_MESSAGING_ARTIFACT.Dependencies        = new [] { FIREBASE_CORE_ARTIFACT, FIREBASE_INSTALLATIONS_ARTIFACT, FIREBASE_AB_TESTING_ARTIFACT };
 	FIREBASE_INSTALLATIONS_ARTIFACT.Dependencies           = new [] { FIREBASE_CORE_ARTIFACT };
 	FIREBASE_PERFORMANCE_MONITORING_ARTIFACT.Dependencies  = new [] { FIREBASE_CORE_ARTIFACT, FIREBASE_INSTALLATIONS_ARTIFACT, FIREBASE_AB_TESTING_ARTIFACT, FIREBASE_REMOTE_CONFIG_ARTIFACT };
 	FIREBASE_REMOTE_CONFIG_ARTIFACT.Dependencies           = new [] { FIREBASE_CORE_ARTIFACT, FIREBASE_INSTALLATIONS_ARTIFACT, FIREBASE_AB_TESTING_ARTIFACT };
@@ -192,9 +192,9 @@ void SetArtifactsPodSpecs ()
 	FIREBASE_DATABASE_ARTIFACT.PodSpecs = new [] {
 		PodSpec.Create ("FirebaseDatabase", "12.6.0", frameworkSource: FrameworkSource.Pods)		
 	};
-	//FIREBASE_IN_APP_MESSAGING_ARTIFACT.PodSpecs = new [] {
-	//	PodSpec.Create ("Firebase", "8.10.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
-	//};
+	FIREBASE_IN_APP_MESSAGING_ARTIFACT.PodSpecs = new [] {
+		PodSpec.Create ("Firebase", "12.6.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
+	};
 	FIREBASE_INSTALLATIONS_ARTIFACT.PodSpecs = new [] {
 		PodSpec.Create ("FirebaseInstallations", "12.6.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("FirebaseSessions",      "12.6.0", frameworkSource: FrameworkSource.Pods)
@@ -404,7 +404,7 @@ void SetArtifactsExtraPodfileLines ()
 	inAppMessagingLines.AddRange (dynamicFrameworkLines);
 	inAppMessagingLines.AddRange (inAppMessagingWorkaround);
 
-	//FIREBASE_IN_APP_MESSAGING_ARTIFACT.ExtraPodfileLines = inAppMessagingLines.ToArray ();
+	FIREBASE_IN_APP_MESSAGING_ARTIFACT.ExtraPodfileLines = inAppMessagingLines.ToArray ();
 }
 
 void SetArtifactsSamples ()

--- a/docs/Firebase/NuGet/InAppMessaging.md
+++ b/docs/Firebase/NuGet/InAppMessaging.md
@@ -1,6 +1,6 @@
 # AdamE.Firebase.iOS.InAppMessaging
 
-.NET bindings for Firebase In-App Messaging on iOS, for use from .NET iOS apps.
+.NET bindings for Firebase In-App Messaging on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
 
 ## What this package provides
 
@@ -36,15 +36,17 @@ These bindings primarily:
 
 ## Supported target frameworks
 
-This package is intended for iOS TFMs such as:
+This package is intended for Apple platform TFMs such as:
 
 - `net9.0-ios`
 - `net10.0-ios`
+- `net9.0-maccatalyst`
+- `net10.0-maccatalyst`
 
-When multi-targeting, condition the package reference so it only restores for iOS targets.
+When multi-targeting, condition the package reference so it only restores for Apple targets.
 
 ```xml
-<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
   <PackageReference Include="AdamE.Firebase.iOS.InAppMessaging" Version="12.6.0" />
 </ItemGroup>
 ```
@@ -77,7 +79,7 @@ inAppMessaging.TriggerEvent("purchase_complete");
 - `AdamE.Firebase.iOS.ABTesting` - package metadata references Firebase A/B Testing for campaign experiment handling.
 - `AdamE.Firebase.iOS.Analytics` - commonly used with In-App Messaging campaign triggers and measurement.
 
-This package is part of the Firebase `12.6.0` package line in this repository. Firebase's aggregate `Firebase/InAppMessaging` `12.6.0` CocoaPods subspec resolves the native `FirebaseInAppMessaging` `12.6.0-beta` pod. The native SDK is iOS-only in this package; Mac Catalyst is intentionally not targeted because the Firebase 12.6 public headers mark In-App Messaging unavailable on Mac Catalyst.
+This package is part of the Firebase `12.6.0` package line in this repository. Firebase's aggregate `Firebase/InAppMessaging` `12.6.0` CocoaPods subspec resolves the native `FirebaseInAppMessaging` `12.6.0-beta` pod.
 
 ## Firebase app configuration
 

--- a/docs/Firebase/NuGet/InAppMessaging.md
+++ b/docs/Firebase/NuGet/InAppMessaging.md
@@ -1,6 +1,6 @@
 # AdamE.Firebase.iOS.InAppMessaging
 
-.NET bindings for Firebase In-App Messaging on Apple platforms, for use from .NET iOS and Mac Catalyst apps.
+.NET bindings for Firebase In-App Messaging on iOS, for use from .NET iOS apps.
 
 ## What this package provides
 
@@ -36,18 +36,16 @@ These bindings primarily:
 
 ## Supported target frameworks
 
-This package is intended for Apple platform TFMs such as:
+This package is intended for iOS TFMs such as:
 
 - `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
-- `net10.0-maccatalyst`
 
-When multi-targeting, condition the package reference so it only restores for Apple targets.
+When multi-targeting, condition the package reference so it only restores for iOS targets.
 
 ```xml
-<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.InAppMessaging" Version="8.10.0.3" />
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+  <PackageReference Include="AdamE.Firebase.iOS.InAppMessaging" Version="12.6.0" />
 </ItemGroup>
 ```
 
@@ -79,7 +77,7 @@ inAppMessaging.TriggerEvent("purchase_complete");
 - `AdamE.Firebase.iOS.ABTesting` - package metadata references Firebase A/B Testing for campaign experiment handling.
 - `AdamE.Firebase.iOS.Analytics` - commonly used with In-App Messaging campaign triggers and measurement.
 
-This package currently uses the `8.10` package line in this repository. Verify compatibility carefully before combining it with Firebase packages from a different MAJOR.MINOR package line.
+This package is part of the Firebase `12.6.0` package line in this repository. Firebase's aggregate `Firebase/InAppMessaging` `12.6.0` CocoaPods subspec resolves the native `FirebaseInAppMessaging` `12.6.0-beta` pod. The native SDK is iOS-only in this package; Mac Catalyst is intentionally not targeted because the Firebase 12.6 public headers mark In-App Messaging unavailable on Mac Catalyst.
 
 ## Firebase app configuration
 

--- a/scripts/FirebaseBindingAudit.Tests/BindingComparerNormalizationTests.cs
+++ b/scripts/FirebaseBindingAudit.Tests/BindingComparerNormalizationTests.cs
@@ -86,6 +86,65 @@ public sealed class BindingComparerNormalizationTests
     }
 
     [Fact]
+    public void Compare_MatchesProtocolInterfaceTypeReferences()
+    {
+        var result = Compare(
+            """
+            [Protocol(Name = "FIRInAppMessagingDisplay")]
+            public interface InAppMessagingDisplay
+            {
+            }
+
+            [BaseType(typeof(NSObject), Name = "FIRInAppMessaging")]
+            public interface InAppMessaging
+            {
+                [Export("messageDisplayComponent")]
+                IInAppMessagingDisplay MessageDisplayComponent { get; set; }
+            }
+            """,
+            """
+            [Protocol]
+            public interface FIRInAppMessagingDisplay
+            {
+            }
+
+            [BaseType(typeof(NSObject))]
+            public interface FIRInAppMessaging
+            {
+                [Export("messageDisplayComponent")]
+                IFIRInAppMessagingDisplay MessageDisplayComponent { get; set; }
+            }
+            """);
+
+        AssertNoFailures(result);
+    }
+
+    [Fact]
+    public void Compare_TreatsProtocolNSObjectBaseAsGeneratorShape()
+    {
+        var result = Compare(
+            """
+            [Protocol(Name = "FIRInAppMessagingDisplay")]
+            public interface InAppMessagingDisplay
+            {
+                [Export("displayMessage:displayDelegate:")]
+                void DisplayMessage(NSObject message, NSObject displayDelegate);
+            }
+            """,
+            """
+            [Protocol]
+            [BaseType(typeof(NSObject))]
+            public interface FIRInAppMessagingDisplay
+            {
+                [Export("displayMessage:displayDelegate:")]
+                void DisplayMessage(NSObject message, NSObject displayDelegate);
+            }
+            """);
+
+        AssertNoFailures(result);
+    }
+
+    [Fact]
     public void Compare_MatchesEnumMemberWithContainingEnumPrefix()
     {
         var result = Compare(
@@ -99,6 +158,48 @@ public sealed class BindingComparerNormalizationTests
             public enum FIRAggregateSource
             {
                 FIRAggregateSourceServer
+            }
+            """);
+
+        AssertNoFailures(result);
+    }
+
+    [Fact]
+    public void Compare_MatchesEnumMemberWithOptionalTypePrefix()
+    {
+        var result = Compare(
+            """
+            public enum InAppMessagingDismissType
+            {
+                TypeUserSwipe,
+                Unspecified
+            }
+            """,
+            """
+            public enum FIRInAppMessagingDismissType
+            {
+                FIRInAppMessagingDismissTypeUserSwipe,
+                FIRInAppMessagingDismissUnspecified
+            }
+            """);
+
+        AssertNoFailures(result);
+    }
+
+    [Fact]
+    public void Compare_MatchesFiamPrefixedSwiftEnumName()
+    {
+        var result = Compare(
+            """
+            public enum InAppMessagingDisplayRenderErrorType
+            {
+                ImageDataInvalid
+            }
+            """,
+            """
+            public enum FIAMDisplayRenderErrorType
+            {
+                FIAMDisplayRenderErrorTypeImageDataInvalid
             }
             """);
 
@@ -220,6 +321,40 @@ public sealed class BindingComparerNormalizationTests
 
             [BaseType(typeof(NSObject))]
             public interface UIApplication
+            {
+            }
+            """);
+
+        AssertNoFailures(result);
+    }
+
+    [Fact]
+    public void Compare_IgnoresGeneratedEmptySupportTypePlaceholders()
+    {
+        var result = Compare(
+            """
+            namespace Firebase.InAppMessaging;
+
+            [BaseType(typeof(NSObject), Name = "FIRInAppMessaging")]
+            public interface InAppMessaging
+            {
+            }
+            """,
+            """
+            namespace FirebaseInAppMessaging;
+
+            [BaseType(typeof(NSObject))]
+            public interface FIRInAppMessaging
+            {
+            }
+
+            [BaseType(typeof(NSObject))]
+            public interface FIRApp
+            {
+            }
+
+            [BaseType(typeof(NSObject))]
+            public interface UIColor
             {
             }
             """);

--- a/scripts/FirebaseBindingAudit/BindingModel.cs
+++ b/scripts/FirebaseBindingAudit/BindingModel.cs
@@ -633,6 +633,15 @@ internal sealed class BindingSyntaxParser
             AddExpandedAliases(aliases, boundType.Name, boundType.ComparisonKey);
             AddExpandedAliases(aliases, boundType.ObjectiveCName, boundType.ComparisonKey);
             AddExpandedAliases(aliases, CreateNamespacePrefixedAlias(boundType.Namespace, boundType.Name), boundType.ComparisonKey);
+            if (boundType.IsProtocol)
+            {
+                AddExpandedAliases(aliases, $"I{boundType.Name}", boundType.ComparisonKey);
+                AddExpandedAliases(aliases, $"I{boundType.ObjectiveCName}", boundType.ComparisonKey);
+                AddExpandedAliases(
+                    aliases,
+                    string.IsNullOrWhiteSpace(boundType.Namespace) ? null : $"{boundType.Namespace}.I{boundType.Name}",
+                    boundType.ComparisonKey);
+            }
         }
 
         foreach (var delegateSurface in delegates)
@@ -711,6 +720,11 @@ internal sealed class BindingSyntaxParser
             AddSimpleAliasVariant(variants, withoutInterfaceObjectiveCPrefix);
         }
 
+        if (TryExpandFirebaseInAppMessagingPrefix(simpleName, out var inAppMessagingName))
+        {
+            AddSimpleAliasVariant(variants, inAppMessagingName);
+        }
+
         return variants;
     }
 
@@ -748,6 +762,20 @@ internal sealed class BindingSyntaxParser
                 result = alias[prefix.Length..];
                 return true;
             }
+        }
+
+        result = string.Empty;
+        return false;
+    }
+
+    private static bool TryExpandFirebaseInAppMessagingPrefix(string alias, out string result)
+    {
+        if (alias.Length > 4 &&
+            alias.StartsWith("FIAM", StringComparison.Ordinal) &&
+            char.IsUpper(alias[4]))
+        {
+            result = $"InAppMessaging{alias[4..]}";
+            return true;
         }
 
         result = string.Empty;
@@ -1196,6 +1224,7 @@ internal sealed class SymbolAliasLookup
     {
         return (alias.Length > 3 && alias.StartsWith("FIR", StringComparison.Ordinal) && char.IsUpper(alias[3])) ||
                (alias.Length > 3 && alias.StartsWith("ABT", StringComparison.Ordinal) && char.IsUpper(alias[3])) ||
+               (alias.Length > 4 && alias.StartsWith("FIAM", StringComparison.Ordinal) && char.IsUpper(alias[4])) ||
                (alias.Length > 4 && alias.StartsWith("IFIR", StringComparison.Ordinal) && char.IsUpper(alias[4])) ||
                (alias.Length > 4 && alias.StartsWith("IABT", StringComparison.Ordinal) && char.IsUpper(alias[4]));
     }
@@ -1231,6 +1260,11 @@ internal sealed class SymbolAliasLookup
         {
             AddLookupKeyVariants(lookupKeys, withoutInterfaceObjectiveCPrefix);
             AddLookupKeyVariants(lookupKeys, withoutInterfaceObjectiveCPrefix[1..]);
+        }
+
+        if (TryExpandFirebaseInAppMessagingPrefix(alias, out var inAppMessagingAlias))
+        {
+            AddLookupKeyVariants(lookupKeys, inAppMessagingAlias);
         }
     }
 
@@ -1272,12 +1306,28 @@ internal sealed class SymbolAliasLookup
         result = string.Empty;
         return false;
     }
+
+    private static bool TryExpandFirebaseInAppMessagingPrefix(string alias, out string result)
+    {
+        if (alias.Length > 4 &&
+            alias.StartsWith("FIAM", StringComparison.Ordinal) &&
+            char.IsUpper(alias[4]))
+        {
+            result = $"InAppMessaging{alias[4..]}";
+            return true;
+        }
+
+        result = string.Empty;
+        return false;
+    }
 }
 
 internal sealed class BindingComparer
 {
     private static readonly HashSet<string> ExternalPlaceholderTypeKeys = new(StringComparer.Ordinal)
     {
+        "FIRApp",
+        "UIColor",
         "UIApplication"
     };
 
@@ -1419,8 +1469,10 @@ internal sealed class BindingComparer
         SymbolAliasLookup aliases,
         List<AuditFinding> failures)
     {
+        var baselineBaseType = NormalizeTypeReference(baseline.BaseType, aliases);
+        var generatedBaseType = NormalizeTypeReference(generated.BaseType, aliases);
         if (!string.Equals(baseline.ContainerKind, generated.ContainerKind, StringComparison.Ordinal) ||
-            !string.Equals(NormalizeTypeReference(baseline.BaseType, aliases), NormalizeTypeReference(generated.BaseType, aliases), StringComparison.Ordinal) ||
+            !HaveEquivalentProtocolBaseTypes(baseline.IsProtocol, generated.IsProtocol, baselineBaseType, generatedBaseType) ||
             baseline.IsProtocol != generated.IsProtocol ||
             baseline.IsStatic != generated.IsStatic)
         {
@@ -1435,6 +1487,26 @@ internal sealed class BindingComparer
                 GeneratedFile: generated.SourceFile,
                 ComparisonTypeKey: baseline.ComparisonKey));
         }
+    }
+
+    private static bool HaveEquivalentProtocolBaseTypes(
+        bool baselineIsProtocol,
+        bool generatedIsProtocol,
+        string baselineBaseType,
+        string generatedBaseType)
+    {
+        if (string.Equals(baselineBaseType, generatedBaseType, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!baselineIsProtocol || !generatedIsProtocol)
+        {
+            return false;
+        }
+
+        return (string.IsNullOrEmpty(baselineBaseType) && string.Equals(generatedBaseType, "nsobject", StringComparison.Ordinal)) ||
+               (string.Equals(baselineBaseType, "nsobject", StringComparison.Ordinal) && string.IsNullOrEmpty(generatedBaseType));
     }
 
     private static void CompareMembers(
@@ -2009,18 +2081,21 @@ internal sealed class BindingComparer
 
     private static string NormalizeEnumMemberKey(string memberKey, EnumSurface enumSurface, SymbolAliasLookup aliases)
     {
+        var enumNameVariants = GetEnumNameVariants(enumSurface, aliases)
+            .SelectMany(ExpandEnumTypeNameVariants)
+            .Distinct(StringComparer.Ordinal);
         var normalizedMember = SymbolAliasLookup.NormalizeLookupKey(StripObjectiveCPrefix(memberKey));
-        foreach (var enumName in GetEnumNameVariants(enumSurface, aliases).OrderByDescending(static name => name.Length))
+        foreach (var enumName in enumNameVariants.OrderByDescending(static name => name.Length))
         {
             var normalizedEnumName = SymbolAliasLookup.NormalizeLookupKey(StripObjectiveCPrefix(enumName));
             if (normalizedMember.Length > normalizedEnumName.Length &&
                 normalizedMember.StartsWith(normalizedEnumName, StringComparison.Ordinal))
             {
-                return normalizedMember[normalizedEnumName.Length..];
+                return NormalizeEnumMemberRemainder(normalizedMember[normalizedEnumName.Length..], enumSurface, aliases);
             }
         }
 
-        return normalizedMember;
+        return NormalizeEnumMemberRemainder(normalizedMember, enumSurface, aliases);
     }
 
     private static IEnumerable<string> GetEnumNameVariants(EnumSurface enumSurface, SymbolAliasLookup aliases)
@@ -2034,6 +2109,35 @@ internal sealed class BindingComparer
             yield return equivalentKey;
             yield return equivalentKey.Split('.').Last();
         }
+    }
+
+    private static IEnumerable<string> ExpandEnumTypeNameVariants(string enumName)
+    {
+        yield return enumName;
+        if (enumName.Length > "Type".Length &&
+            enumName.EndsWith("Type", StringComparison.Ordinal))
+        {
+            yield return enumName[..^"Type".Length];
+        }
+    }
+
+    private static string NormalizeEnumMemberRemainder(string memberRemainder, EnumSurface enumSurface, SymbolAliasLookup aliases)
+    {
+        if (!EnumNameHasTypeSuffix(enumSurface, aliases))
+        {
+            return memberRemainder;
+        }
+
+        return memberRemainder.Length > "type".Length &&
+               memberRemainder.StartsWith("type", StringComparison.Ordinal)
+            ? memberRemainder["type".Length..]
+            : memberRemainder;
+    }
+
+    private static bool EnumNameHasTypeSuffix(EnumSurface enumSurface, SymbolAliasLookup aliases)
+    {
+        return GetEnumNameVariants(enumSurface, aliases)
+            .Any(static name => name.EndsWith("Type", StringComparison.Ordinal));
     }
 
     private static string StripObjectiveCPrefix(string symbol)

--- a/scripts/firebase-binding-audit-suppressions.json
+++ b/scripts/firebase-binding-audit-suppressions.json
@@ -231,6 +231,28 @@
       "evidence": [
         "externals/FirebaseCrashlytics.xcframework/ios-arm64_x86_64-simulator/FirebaseCrashlytics.framework/Headers/FIRCrashlyticsReport.h#L71-L73"
       ]
+    },
+    {
+      "id": "inappmessaging-error-domain-generator-omits-constant",
+      "target": "InAppMessaging",
+      "category": "stale-baseline-binding",
+      "comparisonTypeKey": "FIRInAppMessaging",
+      "comparisonMemberKey": "field|FIRInAppMessagingErrorDomain",
+      "reason": "The Firebase 12.6 header declares FIRInAppMessagingErrorDomain, but swift-dotnet-bindings does not emit this FOUNDATION_EXTERN NSErrorDomain constant.",
+      "evidence": [
+        "externals/FirebaseInAppMessaging.xcframework/ios-arm64/FirebaseInAppMessaging.framework/Headers/FIRInAppMessagingErrors.h#L19-L20"
+      ]
+    },
+    {
+      "id": "inappmessaging-delegate-generator-weakdelegate-shape",
+      "target": "InAppMessaging",
+      "category": "signature-drift",
+      "comparisonTypeKey": "FIRInAppMessaging",
+      "comparisonMemberKey": "export|delegate",
+      "reason": "The Firebase 12.6 header declares id<FIRInAppMessagingDisplayDelegate> delegate; the baseline keeps the typed protocol delegate property while swift-dotnet-bindings emits an NSObject WeakDelegate shape for the same selector.",
+      "evidence": [
+        "externals/FirebaseInAppMessaging.xcframework/ios-arm64/FirebaseInAppMessaging.framework/Headers/FIRInAppMessaging.h#L89-L92"
+      ]
     }
   ]
 }

--- a/scripts/firebase-binding-audit.json
+++ b/scripts/firebase-binding-audit.json
@@ -66,6 +66,18 @@
       "sharpieMode": "auto"
     },
     {
+      "id": "InAppMessaging",
+      "packageId": "Firebase.InAppMessaging",
+      "xcframework": "FirebaseInAppMessaging",
+      "baselineDirectory": "source/Firebase/InAppMessaging",
+      "baselineFiles": [
+        "ApiDefinition.cs",
+        "Enums.cs"
+      ],
+      "helperFiles": [],
+      "sharpieMode": "auto"
+    },
+    {
       "id": "Auth",
       "packageId": "Firebase.Auth",
       "xcframework": "FirebaseAuth",

--- a/source/Firebase/InAppMessaging/ApiDefinition.cs
+++ b/source/Firebase/InAppMessaging/ApiDefinition.cs
@@ -12,6 +12,10 @@ namespace Firebase.InAppMessaging
 	[BaseType (typeof(NSObject), Name = "FIRInAppMessaging")]
 	interface InAppMessaging
 	{
+		// extern NSErrorDomain const FIRInAppMessagingErrorDomain NS_SWIFT_NAME(InAppMessagingErrorDomain);
+		[Field ("FIRInAppMessagingErrorDomain", "__Internal")]
+		NSString ErrorDomain { get; }
+
 		// +(FIRInAppMessaging * _Nonnull)inAppMessaging __attribute__((swift_name("inAppMessaging()")));
 		[Static]
 		[Export ("inAppMessaging")]
@@ -55,6 +59,10 @@ namespace Firebase.InAppMessaging
 		// @property (readonly, copy, nonatomic) UIColor * _Nonnull buttonBackgroundColor;
 		[Export ("buttonBackgroundColor", ArgumentSemantic.Copy)]
 		UIColor ButtonBackgroundColor { get; }
+
+		// -(instancetype _Nonnull)initWithButtonText:(NSString * _Nonnull)buttonText buttonTextColor:(UIColor * _Nonnull)textColor backgroundColor:(UIColor * _Nonnull)backgroundColor;
+		[Export ("initWithButtonText:buttonTextColor:backgroundColor:")]
+		NativeHandle Constructor (string buttonText, UIColor textColor, UIColor backgroundColor);
 	}
 
 	// @interface FIRInAppMessagingImageData : NSObject
@@ -135,6 +143,10 @@ namespace Firebase.InAppMessaging
 		[NullAllowed]
 		[Export ("appData")]
 		NSDictionary AppData { get; }
+
+		// -(instancetype _Nonnull)initWithMessageID:(NSString * _Nonnull)messageID campaignName:(NSString * _Nonnull)campaignName renderAsTestMessage:(BOOL)renderAsTestMessage messageType:(FIRInAppMessagingDisplayMessageType)messageType triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType;
+		[Export ("initWithMessageID:campaignName:renderAsTestMessage:messageType:triggerType:")]
+		NativeHandle Constructor (string messageId, string campaignName, bool renderAsTestMessage, InAppMessagingDisplayMessageType messageType, InAppMessagingDisplayTriggerType triggerType);
 	}
 
 	// @interface FIRInAppMessagingCardDisplay : FIRInAppMessagingDisplayMessage
@@ -185,6 +197,10 @@ namespace Firebase.InAppMessaging
 		[NullAllowed]
 		[Export ("secondaryActionURL")]
 		NSUrl SecondaryActionUrl { get; }
+
+		// -(instancetype _Nonnull)initWithCampaignName:(NSString * _Nonnull)campaignName titleText:(NSString * _Nonnull)title bodyText:(NSString * _Nullable)bodyText textColor:(UIColor * _Nonnull)textColor portraitImageData:(FIRInAppMessagingImageData * _Nonnull)portraitImageData landscapeImageData:(FIRInAppMessagingImageData * _Nullable)landscapeImageData backgroundColor:(UIColor * _Nonnull)backgroundColor primaryActionButton:(FIRInAppMessagingActionButton * _Nonnull)primaryActionButton secondaryActionButton:(FIRInAppMessagingActionButton * _Nullable)secondaryActionButton primaryActionURL:(NSURL * _Nullable)primaryActionURL secondaryActionURL:(NSURL * _Nullable)secondaryActionURL appData:(NSDictionary * _Nullable)appData;
+		[Export ("initWithCampaignName:titleText:bodyText:textColor:portraitImageData:landscapeImageData:backgroundColor:primaryActionButton:secondaryActionButton:primaryActionURL:secondaryActionURL:appData:")]
+		NativeHandle Constructor (string campaignName, string title, [NullAllowed] string bodyText, UIColor textColor, InAppMessagingImageData portraitImageData, [NullAllowed] InAppMessagingImageData landscapeImageData, UIColor backgroundColor, InAppMessagingActionButton primaryActionButton, [NullAllowed] InAppMessagingActionButton secondaryActionButton, [NullAllowed] NSUrl primaryActionUrl, [NullAllowed] NSUrl secondaryActionUrl, [NullAllowed] NSDictionary appData);
 	}
 
 	// @interface FIRInAppMessagingModalDisplay : FIRInAppMessagingDisplayMessage
@@ -223,6 +239,10 @@ namespace Firebase.InAppMessaging
 		// @property(nonatomic, copy, nonnull, readonly) UIColor *textColor;
 		[Export ("textColor", ArgumentSemantic.Copy)]
 		UIColor TextColor { get; }
+
+		// -(instancetype _Nonnull)initWithCampaignName:(NSString * _Nonnull)campaignName titleText:(NSString * _Nonnull)title bodyText:(NSString * _Nullable)bodyText textColor:(UIColor * _Nonnull)textColor backgroundColor:(UIColor * _Nonnull)backgroundColor imageData:(FIRInAppMessagingImageData * _Nullable)imageData actionButton:(FIRInAppMessagingActionButton * _Nullable)actionButton actionURL:(NSURL * _Nullable)actionURL appData:(NSDictionary * _Nullable)appData;
+		[Export ("initWithCampaignName:titleText:bodyText:textColor:backgroundColor:imageData:actionButton:actionURL:appData:")]
+		NativeHandle Constructor (string campaignName, string title, [NullAllowed] string bodyText, UIColor textColor, UIColor backgroundColor, [NullAllowed] InAppMessagingImageData imageData, [NullAllowed] InAppMessagingActionButton actionButton, [NullAllowed] NSUrl actionUrl, [NullAllowed] NSDictionary appData);
 	}
 
 	// @interface FIRInAppMessagingBannerDisplay : FIRInAppMessagingDisplayMessage
@@ -256,6 +276,10 @@ namespace Firebase.InAppMessaging
 		[NullAllowed]
 		[Export ("actionURL")]
 		NSUrl ActionUrl { get; }
+
+		// -(instancetype _Nonnull)initWithCampaignName:(NSString * _Nonnull)campaignName titleText:(NSString * _Nonnull)title bodyText:(NSString * _Nullable)bodyText textColor:(UIColor * _Nonnull)textColor backgroundColor:(UIColor * _Nonnull)backgroundColor imageData:(FIRInAppMessagingImageData * _Nullable)imageData actionURL:(NSURL * _Nullable)actionURL appData:(NSDictionary * _Nullable)appData;
+		[Export ("initWithCampaignName:titleText:bodyText:textColor:backgroundColor:imageData:actionURL:appData:")]
+		NativeHandle Constructor (string campaignName, string title, [NullAllowed] string bodyText, UIColor textColor, UIColor backgroundColor, [NullAllowed] InAppMessagingImageData imageData, [NullAllowed] NSUrl actionUrl, [NullAllowed] NSDictionary appData);
 	}
 
 	// @interface FIRInAppMessagingImageOnlyDisplay : FIRInAppMessagingDisplayMessage
@@ -271,6 +295,10 @@ namespace Firebase.InAppMessaging
 		[NullAllowed]
 		[Export ("actionURL")]
 		NSUrl ActionUrl { get; }
+
+		// -(instancetype _Nonnull)initWithCampaignName:(NSString * _Nonnull)campaignName imageData:(FIRInAppMessagingImageData * _Nonnull)imageData actionURL:(NSURL * _Nullable)actionURL appData:(NSDictionary * _Nullable)appData;
+		[Export ("initWithCampaignName:imageData:actionURL:appData:")]
+		NativeHandle Constructor (string campaignName, InAppMessagingImageData imageData, [NullAllowed] NSUrl actionUrl, [NullAllowed] NSDictionary appData);
 	}
 
 	interface IInAppMessagingDisplayDelegate { }

--- a/source/Firebase/InAppMessaging/InAppMessaging.csproj
+++ b/source/Firebase/InAppMessaging/InAppMessaging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
@@ -8,10 +8,11 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.InAppMessaging</RootNamespace>
     <AssemblyName>Firebase.InAppMessaging</AssemblyName>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>8.10.0.3</FileVersion>
+    <AssemblyVersion>12.6.0</AssemblyVersion>
+    <FileVersion>12.6.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>AdamE.Firebase.iOS.InAppMessaging</PackageId>
@@ -26,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>8.10.0.3</PackageVersion>
+    <PackageVersion>12.6.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />
@@ -45,7 +46,8 @@
       <Kind>Framework</Kind>
       <SmartLink>True</SmartLink>
       <ForceLoad>True</ForceLoad>
-      <Frameworks>CoreTelephony QuartzCore SystemConfiguration</Frameworks>
+      <Frameworks>CoreTelephony QuartzCore SystemConfiguration UIKit</Frameworks>
+      <LinkerFlags>-ObjC</LinkerFlags>
     </NativeReference>
   </ItemGroup>
   <ItemGroup>
@@ -53,9 +55,6 @@
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Xamarin.Build.Download" Version="0.11.4" PrivateAssets="None" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" PrivateAssets="None" />

--- a/source/Firebase/InAppMessaging/InAppMessaging.csproj
+++ b/source/Firebase/InAppMessaging/InAppMessaging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
+    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/InAppMessaging/Loader.cs
+++ b/source/Firebase/InAppMessaging/Loader.cs
@@ -15,9 +15,9 @@ namespace Firebase.InAppMessaging {
 
 namespace ApiDefinition
 {
-	partial class Messaging
+	partial class InAppMessaging
 	{
-		static Messaging ()
+		static InAppMessaging ()
 		{
 			Firebase.InAppMessaging.Loader.ForceLoad ();
 		}

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseBindingSurfaceCoverage.InAppMessaging.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseBindingSurfaceCoverage.InAppMessaging.cs
@@ -1,0 +1,35 @@
+#if ENABLE_BINDING_SURFACE_COVERAGE
+#if ENABLE_BINDING_SURFACE_COVERAGE_INAPPMESSAGING
+using FirebaseInAppMessagingClient = Firebase.InAppMessaging.InAppMessaging;
+#endif
+
+namespace FirebaseFoundationE2E;
+
+public static partial class FirebaseBindingSurfaceCoverage
+{
+    static async Task<BindingSurfaceCoverageTargetResult> VerifyInAppMessagingBindingSurfaceAsync(BindingSurfaceCoverageDocument document)
+    {
+        var result = await ExecuteTargetAsync(document, "InAppMessaging");
+#if ENABLE_BINDING_SURFACE_COVERAGE_INAPPMESSAGING
+        ExerciseInAppMessagingBoundary();
+#endif
+        return result;
+    }
+
+#if ENABLE_BINDING_SURFACE_COVERAGE_INAPPMESSAGING
+    static void ExerciseInAppMessagingBoundary()
+    {
+        var inAppMessaging = FirebaseInAppMessagingClient.SharedInstance
+            ?? throw new InvalidOperationException("Firebase.InAppMessaging.InAppMessaging.SharedInstance returned null.");
+
+        var isSuppressed = inAppMessaging.MessageDisplaySuppressed;
+        inAppMessaging.MessageDisplaySuppressed = isSuppressed;
+
+        var automaticCollection = inAppMessaging.AutomaticDataCollectionEnabled;
+        inAppMessaging.AutomaticDataCollectionEnabled = automaticCollection;
+
+        inAppMessaging.TriggerEvent("codex-binding-surface-e2e");
+    }
+#endif
+}
+#endif

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseBindingSurfaceCoverage.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseBindingSurfaceCoverage.cs
@@ -82,6 +82,7 @@ public static partial class FirebaseBindingSurfaceCoverage
             "Analytics" => VerifyAnalyticsBindingSurfaceAsync(document),
             "AppCheck" => VerifyAppCheckBindingSurfaceAsync(document),
             "AppDistribution" => VerifyAppDistributionBindingSurfaceAsync(document),
+            "InAppMessaging" => VerifyInAppMessagingBindingSurfaceAsync(document),
             "Auth" => VerifyAuthBindingSurfaceAsync(document),
             "CloudFirestore" => VerifyCloudFirestoreBindingSurfaceAsync(document),
             "CloudFunctions" => VerifyCloudFunctionsBindingSurfaceAsync(document),
@@ -234,19 +235,46 @@ public static partial class FirebaseBindingSurfaceCoverage
 
     static Type ResolveManagedType(BindingSurfaceDescriptor surface)
     {
-        var type = ResolveManagedType(surface.RuntimeTypeName, surface.AssemblyName);
-        if (type is null && surface.RuntimeTypeName.StartsWith("Firebase.", StringComparison.Ordinal))
+        foreach (var runtimeTypeName in CreateRuntimeTypeNameCandidates(surface))
         {
-            var runtimeParts = surface.RuntimeTypeName.Split('.');
-            if (runtimeParts.Length > 2 && !runtimeParts[^1].StartsWith('I'))
+            var type = ResolveManagedType(runtimeTypeName, surface.AssemblyName);
+            if (type is not null)
             {
-                var interfaceName = string.Join('.', runtimeParts.Take(runtimeParts.Length - 1).Append($"I{runtimeParts[^1]}"));
-                type = ResolveManagedType(interfaceName, surface.AssemblyName);
+                return type;
             }
         }
 
-        return type ?? throw new TypeLoadException($"Managed type '{surface.RuntimeTypeName}' was not found in assembly '{surface.AssemblyName}'.");
+        throw new TypeLoadException($"Managed type '{surface.RuntimeTypeName}' was not found in assembly '{surface.AssemblyName}'.");
     }
+
+    static IEnumerable<string> CreateRuntimeTypeNameCandidates(BindingSurfaceDescriptor surface)
+    {
+        yield return surface.RuntimeTypeName;
+
+        if (!surface.RuntimeTypeName.StartsWith("Firebase.", StringComparison.Ordinal))
+        {
+            yield break;
+        }
+
+        var runtimeParts = surface.RuntimeTypeName.Split('.');
+        if (runtimeParts.Length <= 2 || IsInterfaceStyleName(runtimeParts[^1]))
+        {
+            yield break;
+        }
+
+        var runtimeNamespace = string.Join('.', runtimeParts.Take(runtimeParts.Length - 1));
+        yield return $"{runtimeNamespace}.I{runtimeParts[^1]}";
+
+        if (surface.IsProtocol)
+        {
+            yield return $"{runtimeNamespace}.{runtimeParts[^1]}Wrapper";
+        }
+    }
+
+    static bool IsInterfaceStyleName(string typeName) =>
+        typeName.Length > 1 &&
+        typeName[0] == 'I' &&
+        char.IsUpper(typeName[1]);
 
     static void ResolveManagedMember(Type type, BindingSurfaceDescriptor surface)
     {

--- a/tests/E2E/Firebase.Foundation/README.md
+++ b/tests/E2E/Firebase.Foundation/README.md
@@ -103,7 +103,7 @@ Pack the active Firebase set when running the aggregate lane:
 
 ```sh
 dotnet tool restore
-dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.ABTesting,Firebase.Analytics,Firebase.AppCheck,Firebase.AppDistribution,Firebase.Auth,Firebase.CloudFirestore,Firebase.CloudFunctions,Firebase.CloudMessaging,Firebase.Core,Firebase.Crashlytics,Firebase.Database,Firebase.Installations,Firebase.PerformanceMonitoring,Firebase.RemoteConfig,Firebase.Storage"
+dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.ABTesting,Firebase.Analytics,Firebase.AppCheck,Firebase.AppDistribution,Firebase.Auth,Firebase.CloudFirestore,Firebase.CloudFunctions,Firebase.CloudMessaging,Firebase.Core,Firebase.Crashlytics,Firebase.Database,Firebase.InAppMessaging,Firebase.Installations,Firebase.PerformanceMonitoring,Firebase.RemoteConfig,Firebase.Storage"
 ```
 
 Run a representative target or the full active set with:

--- a/tests/E2E/Firebase.Foundation/binding-surface-coverage.json
+++ b/tests/E2E/Firebase.Foundation/binding-surface-coverage.json
@@ -42,6 +42,21 @@
       "requiredExtraPackages": []
     },
     {
+      "id": "InAppMessaging",
+      "packageId": "AdamE.Firebase.iOS.InAppMessaging",
+      "coverageCaseMethod": "VerifyInAppMessagingBindingSurfaceAsync",
+      "sourceFiles": [
+        "source/Firebase/InAppMessaging/ApiDefinition.cs",
+        "source/Firebase/InAppMessaging/Enums.cs"
+      ],
+      "requiredExtraPackages": [
+        {
+          "id": "AdamE.Firebase.iOS.ABTesting",
+          "version": "12.6.0"
+        }
+      ]
+    },
+    {
       "id": "Auth",
       "packageId": "AdamE.Firebase.iOS.Auth",
       "coverageCaseMethod": "VerifyAuthBindingSurfaceAsync",

--- a/tools/e2e/run-firebase-foundation.sh
+++ b/tools/e2e/run-firebase-foundation.sh
@@ -224,7 +224,6 @@ PY
     "-p:BindingSurfaceCoveragePropsPath=$binding_surface_props"
   )
   restore_args+=("--force-evaluate")
-  restore_args+=("-p:TargetFramework=net9.0-ios")
 
   echo "Binding surface coverage target: $binding_surface_target"
 fi

--- a/tools/e2e/run-firebase-foundation.sh
+++ b/tools/e2e/run-firebase-foundation.sh
@@ -224,6 +224,7 @@ PY
     "-p:BindingSurfaceCoveragePropsPath=$binding_surface_props"
   )
   restore_args+=("--force-evaluate")
+  restore_args+=("-p:TargetFramework=net9.0-ios")
 
   echo "Binding surface coverage target: $binding_surface_target"
 fi


### PR DESCRIPTION
## Summary
- Re-enable `Firebase.InAppMessaging` as a 12.6.0 Firebase package sourced from the aggregate `Firebase/InAppMessaging` pod subspec.
- Modernize the InAppMessaging binding project for the active package shape, targeting both iOS and Mac Catalyst.
- Refresh the 12.6 binding surface with missing constructors and `FIRInAppMessagingErrorDomain`, then add InAppMessaging to the audit and exhaustive E2E coverage target sets.

## Notes
- The native Firebase aggregate `12.6.0` subspec resolves `FirebaseInAppMessaging 12.6.0-beta`; the NuGet package remains `AdamE.Firebase.iOS.InAppMessaging` version `12.6.0` to match this repo's Firebase release line.
- The packaged InAppMessaging output now includes `net9.0-maccatalyst` and `net10.0-maccatalyst` assets alongside the iOS assets.
- The coverage harness now recognizes generated protocol interface/wrapper shapes so protocol-only surfaces like `FIRInAppMessagingDisplay` are validated without forcing a different binding shape.
- The audit suppressions added here are generator-shape suppressions with header evidence: the exported error-domain constant is real, and the typed delegate property intentionally differs from swift-dotnet-bindings' weak `NSObject` output.

## Validation
- `dotnet tool run dotnet-cake -- --target=nuget --names="Firebase.InAppMessaging"`
- `scripts/compare-firebase-bindings.sh --targets InAppMessaging`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --binding-surface-target InAppMessaging`
- `dotnet test scripts/FirebaseBindingAudit.Tests/FirebaseBindingAudit.Tests.csproj --no-restore`
- `dotnet tool restore && dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.InAppMessaging`
- Confirmed `AdamE.Firebase.iOS.InAppMessaging.12.6.0.nupkg` contains `net9.0-maccatalyst` and `net10.0-maccatalyst` assets.
- `git diff --check`