### PR TITLE
[codex] Fix PerformanceMonitoring payload size bindings

### DIFF
--- a/source/Firebase/PerformanceMonitoring/ApiDefinition.cs
+++ b/source/Firebase/PerformanceMonitoring/ApiDefinition.cs
@@ -23,11 +23,11 @@ namespace Firebase.PerformanceMonitoring
 
 		// @property (assign, nonatomic) long requestPayloadSize;
 		[Export ("requestPayloadSize")]
-		nint RequestPayloadSize { get; set; }
+		long RequestPayloadSize { get; set; }
 
 		// @property (assign, nonatomic) long responsePayloadSize;
 		[Export ("responsePayloadSize")]
-		nint ResponsePayloadSize { get; set; }
+		long ResponsePayloadSize { get; set; }
 
 		// @property (copy, nonatomic) NSString * _Nullable responseContentType;
 		[NullAllowed, Export ("responseContentType")]


### PR DESCRIPTION
## Summary

- Change `Firebase.PerformanceMonitoring.HttpMetric.RequestPayloadSize` from `nint` to `long`.
- Change `Firebase.PerformanceMonitoring.HttpMetric.ResponsePayloadSize` from `nint` to `long`.

## Why

The Firebase 12.6.0 header declares both payload size properties as native `long` values. The binding audit flagged the existing `nint` declarations as type drift.

## Validation

- `scripts/compare-firebase-bindings.sh --targets PerformanceMonitoring --output-dir output/firebase-binding-audit-performancemonitoring-20260414-175244`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.PerformanceMonitoring`

The targeted audit passed with zero unsuppressed failures, and the focused package build completed successfully.