### PR TITLE
[codex] Fix Installations error code backing type

### DIFF
--- a/source/Firebase/Installations/Enums.cs
+++ b/source/Firebase/Installations/Enums.cs
@@ -4,7 +4,7 @@ using ObjCRuntime;
 namespace Firebase.Installations
 {
 	[Native]
-	public enum InstallationsErrorCode : ulong
+	public enum InstallationsErrorCode : long
 	{
 		Unknown = 0,
 		Keychain = 1,


### PR DESCRIPTION
## Summary

- Change `Firebase.Installations.InstallationsErrorCode` from `ulong` to `long`.

## Why

The Firebase 12.6.0 public header declares `FIRInstallationsErrorCode` with `NS_ERROR_ENUM`, which expands to an `NSInteger`-backed enum. On the target SDK/architecture, `NSInteger` maps to signed `long`, not unsigned `ulong`.

The broader audit suppressions are intentionally left out of this PR and will be collected separately after the real binding fixes are done.

## Validation

- Verified `FIRInstallationsErrors.h` declares `typedef NS_ERROR_ENUM(kFirebaseInstallationsErrorDomain, FIRInstallationsErrorCode)`.
- Verified `NS_ERROR_ENUM` expands to `enum FIRInstallationsErrorCode : NSInteger` through clang preprocessing.
- Verified clang AST maps `NSInteger` to `long`.
- `scripts/compare-firebase-bindings.sh --targets Installations --output-dir output/firebase-binding-audit-installations-fixed-20260415-004505`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.Installations`

The targeted Installations audit passed with zero unsuppressed failures when the reviewed local suppressions were present, and the focused Installations package build completed with zero warnings and zero errors.
