### PR TITLE
[codex] Fix AppCheck provider factory return type

### DIFF
--- a/source/Firebase/AppCheck/ApiDefinition.cs
+++ b/source/Firebase/AppCheck/ApiDefinition.cs
@@ -80,7 +80,7 @@ namespace Firebase.AppCheck {
 		[Abstract]
 		[Export ("createProviderWithApp:")]
 		[return: NullAllowed]
-		NSObject CreateProviderWithApp (App app);
+		IAppCheckProvider CreateProviderWithApp (App app);
 	}
 
 	// @interface FIRAppCheckToken : NSObject	


### PR DESCRIPTION
## Summary

- Change `FIRAppCheckProviderFactory.createProviderWithApp:` to return `IAppCheckProvider` instead of `NSObject`.
- Match the FirebaseAppCheck `.xcframework` header, which declares a nullable `id<FIRAppCheckProvider>` return.
- Keep audit suppression changes out of this PR.

## Validation

- `scripts/compare-firebase-bindings.sh --targets AppCheck --output-dir output/firebase-binding-audit-appcheck-fixed-20260415-032809`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.AppCheck`
