### PR TITLE
[codex] Fix CloudMessaging error code backing type

### DIFF
--- a/source/Firebase/CloudMessaging/Enums.cs
+++ b/source/Firebase/CloudMessaging/Enums.cs
@@ -4,7 +4,7 @@ using ObjCRuntime;
 namespace Firebase.CloudMessaging
 {
 	[Native]
-	public enum ErrorCode : ulong
+	public enum ErrorCode : long
 	{
 		Unknown = 0,
 		Authentication = 1,


### PR DESCRIPTION
## Summary

- Change `Firebase.CloudMessaging.ErrorCode` from `ulong` to `long`.
- Match FirebaseMessaging's `FIRMessagingError` declaration, which is an `NS_ERROR_ENUM` and therefore `NSInteger` backed.
- Keep audit suppression changes out of this PR.

## Validation

- `scripts/compare-firebase-bindings.sh --targets CloudMessaging --output-dir output/firebase-binding-audit-cloudmessaging-fixed-20260415-135941`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.CloudMessaging`
