### PR TITLE
[codex] Fix Database emulator port type

### DIFF
--- a/source/Firebase/Database/ApiDefinition.cs
+++ b/source/Firebase/Database/ApiDefinition.cs
@@ -85,7 +85,7 @@ namespace Firebase.Database
 
 		// - (void) useEmulatorWithHost:(NSString*) host port:(NSInteger) port;		
 		[Export ("useEmulatorWithHost:port:")]
-		void UseEmulatorWithHost (string host, uint port);
+		void UseEmulatorWithHost (string host, nint port);
 	}
 
 	delegate void DatabaseQueryUpdateHandler (DataSnapshot snapshot);


### PR DESCRIPTION
## Summary

- Change `Firebase.Database.Database.UseEmulatorWithHost` port from `uint` to `nint`.
- Match FirebaseDatabase's `useEmulatorWithHost:port:` declaration, which uses `NSInteger` for the port.
- Keep audit suppression changes out of this PR.

## Validation

- `scripts/compare-firebase-bindings.sh --targets Database --output-dir output/firebase-binding-audit-database-fixed-20260415-141121`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.Database`
