### PR TITLE
[codex] Fix Storage API bindings

### DIFF
--- a/source/Firebase/Storage/ApiDefinition.cs
+++ b/source/Firebase/Storage/ApiDefinition.cs
@@ -49,6 +49,10 @@ namespace Firebase.Storage
 		[Export ("maxOperationRetryTime")]
 		double MaxOperationRetryTime { get; set; }
 
+		// @property int64_t uploadChunkSizeBytes;
+		[Export ("uploadChunkSizeBytes")]
+		long UploadChunkSizeBytes { get; set; }
+
 		// @property (nonatomic, strong) dispatch_queue_t _Nonnull callbackQueue;
 		[Export ("callbackQueue", ArgumentSemantic.Strong)]
 		DispatchQueue CallbackQueue { get; set; }
@@ -67,7 +71,7 @@ namespace Firebase.Storage
 
 		// - (void) useEmulatorWithHost:(NSString*) host port:(NSInteger) port;
 		[Export ("useEmulatorWithHost:port:")]
-		void UseEmulatorWithHost (string host, uint port);
+		void UseEmulatorWithHost (string host, nint port);
 	}
 
 	// @interface FIRStorageDownloadTask : FIRStorageObservableTask <FIRStorageTaskManagement>

--- a/source/Firebase/Storage/Enums.cs
+++ b/source/Firebase/Storage/Enums.cs
@@ -28,6 +28,9 @@ namespace Firebase.Storage
 		NonMatchingChecksum = -13031,
 		DownloadSizeExceeded = -13032,
 		Cancelled = -13040,
-		InvalidArgument = -13050
+		InvalidArgument = -13050,
+		BucketMismatch = -13051,
+		InternalError = -13052,
+		PathError = -13053
 	}
 }


### PR DESCRIPTION
## Summary

- Bind `FIRStorage.useEmulatorWithHost:port:` with `nint` to match the native `NSInteger` parameter.
- Add the `uploadChunkSizeBytes` Storage property exposed by the FirebaseStorage Swift header.
- Add the missing `StorageErrorCode` enum values from FirebaseStorage 12.6.0.

## Validation

- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.Storage`

## Notes

Audit suppression updates are intentionally excluded from this PR; they remain local for the later combined suppression PR.