### PR TITLE
[codex] Fix CloudFirestore emulator port type

### DIFF
--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -712,7 +712,7 @@ namespace Firebase.CloudFirestore
 
 		// - (void) useEmulatorWithHost:(NSString*) host port:(NSInteger) port;		
 		[Export ("useEmulatorWithHost:port:")]
-		void UseEmulatorWithHost (string host, uint port);
+		void UseEmulatorWithHost (string host, nint port);
 
 		// -(void)enableNetworkWithCompletion:(void (^ _Nullable)(NSError * _Nullable))completion;
 		[Async]


### PR DESCRIPTION
## Summary

- Updates the CloudFirestore `useEmulatorWithHost:port:` binding to use `nint` for the port parameter.
- Matches the native Firebase 12.6.0 header, which declares the port as `NSInteger`.
- Keeps audit suppression updates out of this PR so they can be collected separately.

## Impact

This corrects the managed binding signature for the emulator configuration API without changing unrelated CloudFirestore surface area.

## Validation

- Checked `FIRFirestore.h` declares `- (void)useEmulatorWithHost:(NSString *)host port:(NSInteger)port;`.
- Built `Firebase.CloudFirestore` package successfully.
- Reran focused CloudFirestore binding audit after local suppressions: 0 failures, 47 suppressed, 0 stale suppressions, 0 invalid suppressions.