### PR TITLE
[codex] Fix Firebase CloudFunctions binding surface

### DIFF
--- a/source/Firebase/CloudFunctions/ApiDefinition.cs
+++ b/source/Firebase/CloudFunctions/ApiDefinition.cs
@@ -47,14 +47,39 @@ namespace Firebase.CloudFunctions
 		[Export("HTTPSCallableWithName:")]
 		HttpsCallable HttpsCallable(string name);
 
+		//- (FIRHTTPSCallable *)HTTPSCallableWithName:(NSString *)name options:(FIRHTTPSCallableOptions *)options;
+		[Export("HTTPSCallableWithName:options:")]
+		HttpsCallable HttpsCallable(string name, HttpsCallableOptions options);
+
+		//- (FIRHTTPSCallable *)HTTPSCallableWithURL:(NSURL *)url;
+		[Export("HTTPSCallableWithURL:")]
+		HttpsCallable HttpsCallable(NSUrl url);
+
+		//- (FIRHTTPSCallable *)HTTPSCallableWithURL:(NSURL *)url options:(FIRHTTPSCallableOptions *)options;
+		[Export("HTTPSCallableWithURL:options:")]
+		HttpsCallable HttpsCallable(NSUrl url, HttpsCallableOptions options);
+
 		//- (void)useEmulatorWithHost:(NSString *)host port:(NSInteger) port;
 		[Export ("useEmulatorWithHost:port:")]
-		void UseEmulatorOriginWithHost (string host, uint port);
+		void UseEmulatorWithHost (string host, nint port);
 	}
 
 	// void (^)(FIRHTTPSCallableResult *_Nullable result, NSError *_Nullable error);
 	delegate void HttpsCallableResultHandler([NullAllowed] HttpsCallableResult result, [NullAllowed] NSError error);
 
+	[DisableDefaultCtor]
+	[BaseType(typeof(NSObject), Name = "FIRHTTPSCallableOptions")]
+	interface HttpsCallableOptions
+	{
+		//- (instancetype)initWithRequireLimitedUseAppCheckTokens:(BOOL)requireLimitedUseAppCheckTokens;
+		[DesignatedInitializer]
+		[Export("initWithRequireLimitedUseAppCheckTokens:")]
+		NativeHandle Constructor(bool requireLimitedUseAppCheckTokens);
+
+		//@property(nonatomic, readonly) BOOL requireLimitedUseAppCheckTokens;
+		[Export("requireLimitedUseAppCheckTokens")]
+		bool RequireLimitedUseAppCheckTokens { get; }
+	}
 
 	[DisableDefaultCtor]
 	[BaseType(typeof(NSObject), Name = "FIRHTTPSCallable")]

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseRuntimeDriftCases.cs
@@ -2675,13 +2675,13 @@ static partial class FirebaseRuntimeDriftCases
         {
             try
             {
-                functions.UseEmulatorOriginWithHost("127.0.0.1", 5002);
+                functions.UseEmulatorWithHost("127.0.0.1", (nint)5002);
             }
             catch (ObjCException ex)
             {
                 throw new InvalidOperationException(
                     $"Selector '{liveSelector}' should not throw after the binding fix, but observed {ex.GetType().FullName}. " +
-                    $"Runtime host argument type: {typeof(string).FullName}. Runtime port argument type: {typeof(uint).FullName}. " +
+                    $"Runtime host argument type: {typeof(string).FullName}. Runtime port argument type: {typeof(nint).FullName}. " +
                     $"NSException.Name: {objcExceptionProbe.Name}. " +
                     $"NSException.Reason: {objcExceptionProbe.Reason}. " +
                     $"Marshal mode: {objcExceptionProbe.Mode}.",
@@ -2698,7 +2698,7 @@ static partial class FirebaseRuntimeDriftCases
             return Task.FromResult(
                 $"Removed stale managed selector '{staleSelector}' and property 'EmulatorOrigin'. " +
                 $"Live selector '{liveSelector}' completed without ObjC exception after the binding fix. " +
-                $"Runtime host argument type: {typeof(string).FullName}. Runtime port argument type: {typeof(uint).FullName}.");
+                $"Runtime host argument type: {typeof(string).FullName}. Runtime port argument type: {typeof(nint).FullName}.");
         }
         finally
         {


### PR DESCRIPTION
## Summary

Updates the Firebase CloudFunctions binding definition to match the Firebase 12.6.0 observable headers and updates the runtime-drift validation case to call the corrected emulator API.

## Changes

- Adds callable overloads for `HTTPSCallableWithName:options:`, `HTTPSCallableWithURL:`, and `HTTPSCallableWithURL:options:`.
- Adds the `FIRHTTPSCallableOptions` binding as `HttpsCallableOptions`.
- Corrects the emulator method binding from the stale `uint`/old managed name shape to `UseEmulatorWithHost(string host, nint port)` for the native `NSInteger` selector.
- Updates the CloudFunctions runtime-drift case to call `UseEmulatorWithHost` with an `nint` port.

## Impact

The callable overloads and options type are additive. The emulator helper method is a source/binary break from the previous `UseEmulatorOriginWithHost(string, uint)` shape, but the native selector is emulator-only and the new binding matches the Firebase 12.6.0 header. The drift-case update keeps the local validation lane compiling against the intentionally updated API.

## Validation

- `scripts/compare-firebase-bindings.sh --targets CloudFunctions --output-dir output/firebase-binding-audit-cloudfunctions-api-fix-suppressed-20260416-163137`
  - Result: `0` failures, `7` suppressed, `0` stale suppressions, `0` invalid suppressions.
- `dotnet build source/Firebase/CloudFunctions/CloudFunctions.csproj`
  - Result: succeeded with existing nullable warnings only.

Note: the full runtime-drift E2E lane was not run locally because the local feed currently lacks `AdamE.Firebase.iOS.CloudFunctions.12.6.0.nupkg`.