### PR TITLE
[codex] Make Firebase audit staged umbrella imports configurable

### DIFF
--- a/scripts/FirebaseBindingAudit.Tests/AuditRunnerTests.cs
+++ b/scripts/FirebaseBindingAudit.Tests/AuditRunnerTests.cs
@@ -169,6 +169,45 @@ public sealed class AuditRunnerTests
         }
     }
 
+    [Fact]
+    public void PrepareStagedXcframeworkForTarget_MaterializesSymlinkBeforeAddingUmbrellaImports()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"firebase-binding-audit-umbrella-{Guid.NewGuid():N}");
+
+        try
+        {
+            var sourceXcframeworkPath = Path.Combine(tempRoot, "externals", "FirebaseFunctions.xcframework");
+            var sourceHeaderPath = Path.Combine(sourceXcframeworkPath, "ios-arm64", "FirebaseFunctions.framework", "Headers", "FirebaseFunctions-umbrella.h");
+            Directory.CreateDirectory(Path.GetDirectoryName(sourceHeaderPath)!);
+            File.WriteAllText(sourceHeaderPath, "FOUNDATION_EXPORT double FirebaseFunctionsVersionNumber;\n");
+
+            var stagedXcframeworkPath = Path.Combine(tempRoot, "frameworks", "FirebaseFunctions.xcframework");
+            Directory.CreateDirectory(Path.GetDirectoryName(stagedXcframeworkPath)!);
+            Directory.CreateSymbolicLink(stagedXcframeworkPath, sourceXcframeworkPath);
+
+            AuditRunner.PrepareStagedXcframeworkForTarget(
+                new AuditTargetDefinition
+                {
+                    Id = "CloudFunctions",
+                    Xcframework = "FirebaseFunctions",
+                    ObjcUmbrellaHeaderImports = ["FirebaseFunctions/FirebaseFunctions-Swift.h"]
+                },
+                stagedXcframeworkPath);
+
+            var stagedHeaderPath = Path.Combine(stagedXcframeworkPath, "ios-arm64", "FirebaseFunctions.framework", "Headers", "FirebaseFunctions-umbrella.h");
+            Assert.Contains("#import <FirebaseFunctions/FirebaseFunctions-Swift.h>", File.ReadAllText(stagedHeaderPath));
+            Assert.DoesNotContain("#import <FirebaseFunctions/FirebaseFunctions-Swift.h>", File.ReadAllText(sourceHeaderPath));
+            Assert.False((new DirectoryInfo(stagedXcframeworkPath).Attributes & FileAttributes.ReparsePoint) != 0);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     private static AuditOptions CreateAuditOptions(bool disableSharpie) =>
         new(
             RepoRoot: string.Empty,

--- a/scripts/FirebaseBindingAudit/AuditRunner.cs
+++ b/scripts/FirebaseBindingAudit/AuditRunner.cs
@@ -221,6 +221,7 @@ internal sealed class AuditRunner
 
         try
         {
+            PrepareStagedXcframeworkForTarget(target, stagedFrameworkPath);
             var projectFile = CreateSwiftBindingProject(projectDirectory, projectName, stagedFrameworkPath, options.GeneratorVersion);
             var buildResult = await BuildTargetProjectAsync(projectFile, projectDirectory, dotnetEnvironment, cancellationToken);
             WriteLogs(logsDirectory, $"{target.Id}-build", buildResult);
@@ -1206,6 +1207,96 @@ internal sealed class AuditRunner
             var destinationPath = Path.Combine(destinationDirectory, Path.GetFileName(xcframeworkDirectory));
             TryCreateDirectorySymlink(destinationPath, xcframeworkDirectory);
         }
+    }
+
+    internal static void PrepareStagedXcframeworkForTarget(AuditTargetDefinition target, string stagedXcframeworkPath)
+    {
+        if (target.ObjcUmbrellaHeaderImports.Length == 0)
+        {
+            return;
+        }
+
+        MaterializeStagedDirectory(stagedXcframeworkPath);
+        AddObjcUmbrellaHeaderImports(stagedXcframeworkPath, target.ObjcUmbrellaHeaderImports);
+    }
+
+    private static void MaterializeStagedDirectory(string stagedDirectoryPath)
+    {
+        var directoryInfo = new DirectoryInfo(stagedDirectoryPath);
+        if (!directoryInfo.Exists || (directoryInfo.Attributes & FileAttributes.ReparsePoint) == 0)
+        {
+            return;
+        }
+
+        var linkTarget = directoryInfo.LinkTarget;
+        if (string.IsNullOrWhiteSpace(linkTarget))
+        {
+            throw new InvalidOperationException($"Unable to resolve symlink target for '{stagedDirectoryPath}'.");
+        }
+
+        var sourcePath = Path.IsPathRooted(linkTarget)
+            ? linkTarget
+            : Path.GetFullPath(Path.Combine(directoryInfo.Parent?.FullName ?? Directory.GetCurrentDirectory(), linkTarget));
+        if (!Directory.Exists(sourcePath))
+        {
+            throw new InvalidOperationException($"Symlink target '{sourcePath}' does not exist for '{stagedDirectoryPath}'.");
+        }
+
+        Directory.Delete(stagedDirectoryPath);
+        CopyDirectory(sourcePath, stagedDirectoryPath);
+    }
+
+    private static void AddObjcUmbrellaHeaderImports(string xcframeworkPath, IReadOnlyList<string> imports)
+    {
+        var importLines = imports
+            .Select(NormalizeObjcImportLine)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (importLines.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var umbrellaHeaderPath in Directory.EnumerateFiles(xcframeworkPath, "*-umbrella.h", SearchOption.AllDirectories))
+        {
+            var content = File.ReadAllText(umbrellaHeaderPath);
+            var additions = importLines
+                .Where(importLine => !content.Contains(importLine, StringComparison.Ordinal))
+                .ToList();
+            if (additions.Count == 0)
+            {
+                continue;
+            }
+
+            var builder = new StringBuilder(content);
+            if (builder.Length > 0 && builder[^1] != '\n')
+            {
+                builder.AppendLine();
+            }
+
+            foreach (var addition in additions)
+            {
+                builder.AppendLine(addition);
+            }
+
+            File.WriteAllText(umbrellaHeaderPath, builder.ToString());
+        }
+    }
+
+    private static string NormalizeObjcImportLine(string import)
+    {
+        var trimmedImport = import.Trim();
+        if (trimmedImport.StartsWith("#import ", StringComparison.Ordinal))
+        {
+            return trimmedImport;
+        }
+
+        if (trimmedImport.StartsWith("<", StringComparison.Ordinal) || trimmedImport.StartsWith("\"", StringComparison.Ordinal))
+        {
+            return $"#import {trimmedImport}";
+        }
+
+        return $"#import <{trimmedImport}>";
     }
 
     private static void StageSharpieFrameworkSlices(

--- a/scripts/FirebaseBindingAudit/Configuration.cs
+++ b/scripts/FirebaseBindingAudit/Configuration.cs
@@ -34,6 +34,8 @@ internal sealed class AuditTargetDefinition
 
     public string[] HelperFiles { get; set; } = [];
 
+    public string[] ObjcUmbrellaHeaderImports { get; set; } = [];
+
     public string? SharpieMode { get; set; }
 
     public bool UseSharpieComparisonFallback { get; set; }

--- a/scripts/firebase-binding-audit.json
+++ b/scripts/firebase-binding-audit.json
@@ -118,6 +118,9 @@
       "helperFiles": [
         "Extension.cs"
       ],
+      "objcUmbrellaHeaderImports": [
+        "FirebaseFunctions/FirebaseFunctions-Swift.h"
+      ],
       "sharpieMode": "auto"
     },
     {


### PR DESCRIPTION
## Summary

Adds target-level support for patching ObjC umbrella imports in the Firebase binding audit's staged xcframework copy. This makes CloudFunctions generation non-empty by importing `FirebaseFunctions/FirebaseFunctions-Swift.h` into the staged `FirebaseFunctions-umbrella.h` before running the Swift binding generator in ObjC mode.

## Changes

- Adds `objcUmbrellaHeaderImports` to Firebase audit target configuration.
- Materializes a staged xcframework symlink before patching umbrella headers, so `/externals` is not modified.
- Appends configured imports only when missing.
- Keeps staged framework preparation inside the target-level guarded audit block, preserving per-target failure isolation if preparation fails.
- Configures CloudFunctions to import `FirebaseFunctions/FirebaseFunctions-Swift.h`.
- Adds unit coverage proving the staged symlink is materialized and the source externals tree is untouched.

## Follow-up

This PR intentionally does not include `scripts/firebase-binding-audit-suppressions.json`. With CloudFunctions now generating a real primary surface, the old committed CloudFunctions generator-empty suppressions become stale and the curated replacements belong in the planned suppression PR.

## Validation

- `dotnet test scripts/FirebaseBindingAudit.Tests/FirebaseBindingAudit.Tests.csproj`
  - Result: `56` passed.
- `scripts/compare-firebase-bindings.sh --targets CloudFunctions --output-dir output/firebase-binding-audit-cloudfunctions-tooling-pr-reviewfix-20260416-172749`
  - Result with the local suppression backlog: `0` failures, `7` suppressed, `0` stale suppressions, `0` invalid suppressions.
  - Generation status: `succeeded`; comparison source: `primary`.