### PR TITLE
[codex] Align Firestore transaction nullable result flow

### DIFF
--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -695,12 +695,12 @@ namespace Firebase.CloudFirestore
 		// -(void)runTransactionWithBlock:(id  _Nullable (^ _Nonnull)(FIRTransaction * _Nonnull, NSError * _Nullable * _Nullable))updateBlock completion:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completion;
 		[Internal]
 		[Export ("runTransactionWithBlock:completion:")]
-		void _RunTransaction (Func<Transaction, IntPtr, NSObject> updateHandler, TransactionCompletionHandler completion);
+		void _RunTransaction (Func<Transaction, IntPtr, NSObject?> updateHandler, TransactionCompletionHandler completion);
 
 		// -(void)runTransactionWithOptions:(FIRTransactionOptions * _Nullable)options block:(id  _Nullable (^ _Nonnull)(FIRTransaction * _Nonnull, NSError * _Nullable * _Nullable))updateBlock completion:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completion;
 		[Internal]
 		[Export ("runTransactionWithOptions:block:completion:")]
-		void _RunTransaction ([NullAllowed] TransactionOptions options, Func<Transaction, IntPtr, NSObject> updateHandler, TransactionCompletionHandler completion);
+		void _RunTransaction ([NullAllowed] TransactionOptions options, Func<Transaction, IntPtr, NSObject?> updateHandler, TransactionCompletionHandler completion);
 
 		// -(FIRWriteBatch * _Nonnull)batch;
 		[Export ("batch")]

--- a/source/Firebase/CloudFirestore/Extensions.cs
+++ b/source/Firebase/CloudFirestore/Extensions.cs
@@ -8,7 +8,7 @@ namespace Firebase.CloudFirestore
 {
 	class CloudFirestoreHelper
 	{
-		public static NSObject [] GetNSObjects (object [] objects)
+		public static NSObject []? GetNSObjects (object []? objects)
 		{
 			if (objects == null)
 				return null;
@@ -25,21 +25,21 @@ namespace Firebase.CloudFirestore
 	public partial class Firestore
 	{
 		// id  _Nullable (^ _Nonnull)(FIRTransaction * _Nonnull, NSError * _Nullable * _Nullable)
-		public delegate NSObject TransactionUpdateHandler (Transaction transaction, ref NSError error);
+		public delegate NSObject? TransactionUpdateHandler (Transaction transaction, ref NSError? error);
 
 		public void RunTransaction (TransactionUpdateHandler updateHandler, TransactionCompletionHandler completion)
 		{
+			if (updateHandler == null)
+				throw new ArgumentNullException (nameof (updateHandler));
+
 			_RunTransaction (InternalUpdateHandler, completion);
 
-			NSObject InternalUpdateHandler (Transaction transaction, IntPtr pError)
+			NSObject? InternalUpdateHandler (Transaction transaction, IntPtr pError)
 			{
-				if (updateHandler == null)
-					return null;
-
-				NSError error = null;
+				NSError? error = null;
 				var result = updateHandler (transaction, ref error);
 
-				if (error != null)
+				if (pError != IntPtr.Zero && error != null)
 					Marshal.WriteIntPtr (pError, error.Handle);
 
 				return result;
@@ -48,26 +48,26 @@ namespace Firebase.CloudFirestore
 
 		public void RunTransaction (TransactionOptions options, TransactionUpdateHandler updateHandler, TransactionCompletionHandler completion)
 		{
+			if (updateHandler == null)
+				throw new ArgumentNullException (nameof (updateHandler));
+
 			_RunTransaction (options, InternalUpdateHandler, completion);
 
-			NSObject InternalUpdateHandler (Transaction transaction, IntPtr pError)
+			NSObject? InternalUpdateHandler (Transaction transaction, IntPtr pError)
 			{
-				if (updateHandler == null)
-					return null;
-
-				NSError error = null;
+				NSError? error = null;
 				var result = updateHandler (transaction, ref error);
 
-				if (error != null)
+				if (pError != IntPtr.Zero && error != null)
 					Marshal.WriteIntPtr (pError, error.Handle);
 
 				return result;
 			}
 		}
 
-		public Task<NSObject> RunTransactionAsync (TransactionUpdateHandler updateHandler)
+		public Task<NSObject?> RunTransactionAsync (TransactionUpdateHandler updateHandler)
 		{
-			var tcs = new TaskCompletionSource<NSObject> ();
+			var tcs = new TaskCompletionSource<NSObject?> ();
 			RunTransaction (updateHandler, (result_, error_) => {
 				if (error_ != null)
 					tcs.SetException (new NSErrorException (error_));
@@ -77,9 +77,9 @@ namespace Firebase.CloudFirestore
 			return tcs.Task;
 		}
 
-		public Task<NSObject> RunTransactionAsync (TransactionOptions options, TransactionUpdateHandler updateHandler)
+		public Task<NSObject?> RunTransactionAsync (TransactionOptions options, TransactionUpdateHandler updateHandler)
 		{
-			var tcs = new TaskCompletionSource<NSObject> ();
+			var tcs = new TaskCompletionSource<NSObject?> ();
 			RunTransaction (options, updateHandler, (result_, error_) => {
 				if (error_ != null)
 					tcs.SetException (new NSErrorException (error_));


### PR DESCRIPTION
## Summary

Aligns the CloudFirestore transaction callback flow with the native nullable result contract.

Changes include:

- make `TransactionUpdateHandler` return `NSObject?` and use `ref NSError?`
- make async transaction helpers return `Task<NSObject?>`
- reject null update handlers explicitly
- only write the native error pointer when both the pointer and managed error are non-null
- update the internal binding delegate return annotation to nullable

## Impact

This is a native-accuracy nullable metadata/source-analysis update. The transaction result can now represent the native `id _Nullable` result without nullable-flow warnings.

## Validation

- `dotnet cake --names=Firebase.CloudFirestore --target=libs`
  - Build succeeded
  - 0 warnings
  - 0 errors
- `scripts/compare-firebase-bindings.sh --targets CloudFirestore --output-dir output/firebase-binding-audit-cloudfirestore-transaction-20260417-171341`
  - CloudFirestore passed
  - 0 failures
  - 47 suppressions matched
  - 0 stale suppressions
  - 0 invalid suppressions