### PR TITLE
[codex] Harden Firebase version string caches

### DIFF
--- a/source/Firebase/Auth/Extension.cs
+++ b/source/Firebase/Auth/Extension.cs
@@ -4,14 +4,24 @@ using ObjCRuntime;
 namespace Firebase.Auth
 {
 	public partial class Auth {
-		static string currentVersion;
+		static string? currentVersion;
 		public static string CurrentVersion { 
 			get {
 				if (currentVersion == null) {
 					IntPtr RTLD_MAIN_ONLY = Dlfcn.dlopen (null, 0);
-					IntPtr ptr = Dlfcn.dlsym (RTLD_MAIN_ONLY, "FirebaseAuthVersionStr");
-					currentVersion = Marshal.PtrToStringAnsi (ptr);
-					Dlfcn.dlclose (RTLD_MAIN_ONLY);
+					if (RTLD_MAIN_ONLY == IntPtr.Zero)
+						throw new InvalidOperationException ("Unable to open the main program handle.");
+
+					try {
+						IntPtr ptr = Dlfcn.dlsym (RTLD_MAIN_ONLY, "FirebaseAuthVersionStr");
+						if (ptr == IntPtr.Zero)
+							throw new InvalidOperationException ("Unable to resolve FirebaseAuthVersionStr.");
+
+						currentVersion = Marshal.PtrToStringAnsi (ptr)
+							?? throw new InvalidOperationException ("Unable to read FirebaseAuthVersionStr.");
+					} finally {
+						Dlfcn.dlclose (RTLD_MAIN_ONLY);
+					}
 				}
 
 				return currentVersion;

--- a/source/Firebase/CloudFunctions/Extension.cs
+++ b/source/Firebase/CloudFunctions/Extension.cs
@@ -3,14 +3,24 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 namespace Firebase.CloudFunctions {
 	public partial class CloudFunctions {
-		static string currentVersion;
+		static string? currentVersion;
 		public static string CurrentVersion {
 			get {
 				if (currentVersion == null) {
 					IntPtr RTLD_MAIN_ONLY = Dlfcn.dlopen (null, 0);
-					IntPtr ptr = Dlfcn.dlsym (RTLD_MAIN_ONLY, "FirebaseCloudFunctionsVersionStr");
-					currentVersion = Marshal.PtrToStringAnsi (ptr);
-					Dlfcn.dlclose (RTLD_MAIN_ONLY);
+					if (RTLD_MAIN_ONLY == IntPtr.Zero)
+						throw new InvalidOperationException ("Unable to open the main program handle.");
+
+					try {
+						IntPtr ptr = Dlfcn.dlsym (RTLD_MAIN_ONLY, "FirebaseCloudFunctionsVersionStr");
+						if (ptr == IntPtr.Zero)
+							throw new InvalidOperationException ("Unable to resolve FirebaseCloudFunctionsVersionStr.");
+
+						currentVersion = Marshal.PtrToStringAnsi (ptr)
+							?? throw new InvalidOperationException ("Unable to read FirebaseCloudFunctionsVersionStr.");
+					} finally {
+						Dlfcn.dlclose (RTLD_MAIN_ONLY);
+					}
 				}
 
 				return currentVersion;

--- a/source/Firebase/Core/Extension.cs
+++ b/source/Firebase/Core/Extension.cs
@@ -8,13 +8,16 @@ namespace Firebase.Core {
 		[DllImport ("__Internal", EntryPoint = "FIRFirebaseVersion")]
 		extern internal static IntPtr _FIRFirebaseVersion ();
 
-		static string firebaseVersion;
+		static string? firebaseVersion;
 		public static string FirebaseVersion {
 			get {
 				if (firebaseVersion == null) {
-
 					IntPtr verStrPtr = _FIRFirebaseVersion ();
-					firebaseVersion = NSString.FromHandle (verStrPtr);
+					if (verStrPtr == IntPtr.Zero)
+						throw new InvalidOperationException ("Unable to resolve FIRFirebaseVersion.");
+
+					firebaseVersion = NSString.FromHandle (verStrPtr)
+						?? throw new InvalidOperationException ("Unable to read FIRFirebaseVersion.");
 				}
 
 				return firebaseVersion;


### PR DESCRIPTION
## Summary

Cleans up the Firebase version-string caches in Core, Auth, and CloudFunctions without changing their public non-null property contracts.

Changes include:

- make the static backing caches nullable
- throw clear `InvalidOperationException`s if native symbol lookup or string conversion unexpectedly returns null
- close `dlopen` handles through `try/finally` in Auth and CloudFunctions

## Impact

Public properties remain non-null. The change removes nullable-flow warnings and replaces unexpected native lookup failures with explicit exceptions.

## Validation

- `dotnet cake --names=Firebase.Core,Firebase.Auth,Firebase.CloudFunctions --target=libs`
  - Build succeeded
  - 0 warnings
  - 0 errors