### PR TITLE
[codex] Validate Analytics consent settings

### DIFF
--- a/source/Firebase/Analytics/Extension.cs
+++ b/source/Firebase/Analytics/Extension.cs
@@ -125,16 +125,23 @@ namespace Firebase.Analytics
 	public partial class Analytics {
 		public static void SetConsent (Dictionary<ConsentType, ConsentStatus> consentSettings)
 		{
+			if (consentSettings == null)
+				throw new ArgumentNullException (nameof (consentSettings));
+
 			var keys = new List<NSString> ();
 			var values = new List<NSString> ();
 
 			foreach (var kv in consentSettings) {
-				keys.Add (global::Firebase.Analytics.ConsentTypeExtensions.GetConstant (kv.Key));
-				values.Add (global::Firebase.Analytics.ConsentStatusExtensions.GetConstant (kv.Value));
+				var key = global::Firebase.Analytics.ConsentTypeExtensions.GetConstant (kv.Key)
+					?? throw new ArgumentOutOfRangeException (nameof (consentSettings), kv.Key, "Unknown consent type.");
+				var value = global::Firebase.Analytics.ConsentStatusExtensions.GetConstant (kv.Value)
+					?? throw new ArgumentOutOfRangeException (nameof (consentSettings), kv.Value, "Unknown consent status.");
+
+				keys.Add (key);
+				values.Add (value);
 			}
 
 			_SetConsent (new NSDictionary<NSString, NSString> (keys.ToArray (), values.ToArray ()));
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary

Adds explicit validation for Analytics consent-setting input before converting enum values to native constants.

Changes include:

- throw `ArgumentNullException` for null consent dictionaries
- throw `ArgumentOutOfRangeException` for unknown consent type values
- throw `ArgumentOutOfRangeException` for unknown consent status values

## Impact

Public API shape is unchanged. Invalid enum inputs now fail before null native constants can be inserted into the dictionary arrays.

## Validation

- `dotnet cake --names=Firebase.Analytics --target=libs`
  - Build exited 0
  - Analytics built with 0 warnings
  - Isolated branch also reports known Core nullable warnings that are fixed separately in PR #169