### PR TITLE
[codex] Harden Storage task snapshot access

### DIFF
--- a/source/Firebase/Storage/Extension.cs
+++ b/source/Firebase/Storage/Extension.cs
@@ -19,14 +19,20 @@ namespace Firebase.Storage
 	{
 		public StorageTask GetTask ()
 		{
+			if (_Task == IntPtr.Zero)
+				throw new InvalidOperationException ("Firebase Storage task snapshot does not contain a task.");
+
 			var task = Runtime.GetNSObject<StorageTask> (_Task);
-			return task;
+			return task ?? throw new InvalidOperationException ("Unable to resolve Firebase Storage task.");
 		}
 
 		public T GetTask<T> () where T : StorageTask
 		{
+			if (_Task == IntPtr.Zero)
+				throw new InvalidOperationException ("Firebase Storage task snapshot does not contain a task.");
+
 			var task = Runtime.GetNSObject<T> (_Task);
-			return task;
+			return task ?? throw new InvalidOperationException ($"Unable to resolve Firebase Storage task as {typeof (T).FullName}.");
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Keeps the Storage task snapshot APIs non-null while replacing nullable-flow assumptions with explicit checked failures.

Changes include:

- throw if the native task handle is unexpectedly zero
- throw if `Runtime.GetNSObject` unexpectedly returns null
- preserve the existing non-null public API shape for `GetTask()` and `GetTask<T>()`

## Impact

No intended public API shape change. If the native non-null `task` property ever violates its contract, callers now get a clear managed exception instead of nullable-flow ambiguity.

## Validation

- `dotnet cake --names=Firebase.Storage --target=libs`
  - Build exited 0
  - Storage built with 0 warnings
  - Isolated branch also reports known dependency warnings from Core and Database that are fixed separately in PR #169 and PR #167