### PR TITLE
[codex] Suppress Firebase build warning noise

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,16 @@ indent_size = 2
 [*.cs]
 max_line_length = 120
 
+# Firebase generated/binding warning suppressions
+[source/Firebase/CloudFirestore/Extensions.cs]
+dotnet_diagnostic.CS8621.severity = none
+
+[source/Firebase/CloudFirestore/obj/**/Firebase.CloudFirestore/*.g.cs]
+dotnet_diagnostic.CS8604.severity = none
+
+[source/Firebase/Database/obj/**/Firebase.Database/DatabaseQuery.g.cs]
+dotnet_diagnostic.CS0109.severity = none
+
 #### Core EditorConfig Options ####
 
 # Indentation and spacing

--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -5,6 +5,8 @@ using Foundation;
 using ObjCRuntime;
 using CoreFoundation;
 
+#pragma warning disable CS8632 // BGen compiles API definitions outside the project nullable context.
+
 namespace Firebase.CloudFirestore
 {
 	// void (^ _Nullable)(NSError * _Nullable)

--- a/source/Google/AppCheckCore/AppCheckCore.csproj
+++ b/source/Google/AppCheckCore/AppCheckCore.csproj
@@ -13,6 +13,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>AdamE.Google.iOS.AppCheckCore</PackageId>


### PR DESCRIPTION
## Summary

Suppresses the remaining non-actionable Firebase build warning noise after the source-level nullable fixes landed.

Changes include:

- suppress generated CloudFirestore `CS8604` warnings under `obj/**/Firebase.CloudFirestore/*.g.cs`
- suppress generated Database `CS0109` warnings for `DatabaseQuery.g.cs`
- suppress CloudFirestore `CS8621` for the BGen transaction delegate nullability mismatch in `Extensions.cs`
- disable `CS8632` in CloudFirestore `ApiDefinition.cs` because BGen compiles API definitions outside the project nullable context
- ignore `NU1603` for `AppCheckCore`, where NuGet resolves `AdamE.Google.iOS.GoogleUtilities` to `8.0.2` within the intended `[8.0.0,9.0.0)` range

## Impact

This does not change binding behavior. It keeps the Firebase release build log focused on actionable warnings.

## Validation

- `dotnet cake --names=Firebase.CloudFirestore,Firebase.Database,Firebase.AppCheck,Firebase.Auth --target=libs`
  - Build succeeded
  - 0 warnings
  - 0 errors
- `dotnet cake --names=Firebase.ABTesting,Firebase.Analytics,Firebase.Auth,Firebase.CloudFirestore,Firebase.CloudFunctions,Firebase.CloudMessaging,Firebase.Crashlytics,Firebase.Database,Firebase.InAppMessaging,Firebase.Installations,Firebase.PerformanceMonitoring,Firebase.RemoteConfig,Firebase.Storage,Firebase.AppDistribution,Firebase.AppCheck --target=libs`
  - Build succeeded
  - 0 warnings
  - 0 errors