### PR TITLE
[codex] Update Firebase 12.6.0 documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ If your project targets multiple platforms, keep these packages inside Apple-onl
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.5.0.4" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
 </ItemGroup>
 ```
 
@@ -74,26 +74,30 @@ Archiving can still be more reliable on macOS or from the command line.
 
 The lists below reflect what is currently published on [nuget.org](https://www.nuget.org/profiles/adamessenmacher) under the `adamessenmacher` owner profile. That is intentionally different from the repo state in [`components.cake`](components.cake): the repo can contain projects or version bumps that have not been published yet.
 
+Firebase `12.6.0` is the current published Firebase package line.
+
 ### Currently published on nuget.org
 
 #### Firebase packages (`AdamE.Firebase.iOS.*`)
 
 | Package | Version |
 | --- | --- |
-| `ABTesting` | `12.5.0.4` |
-| `Analytics` | `12.5.0.4` |
-| `AppCheck` | `12.5.0.4` |
-| `Auth` | `12.5.0.4` |
-| `CloudFirestore` | `12.5.0.4` |
-| `CloudFunctions` | `12.5.0.4` |
-| `CloudMessaging` | `12.5.0.4` |
-| `Core` | `12.5.0.4` |
-| `Crashlytics` | `12.5.0.4` |
-| `Database` | `12.5.0.4` |
-| `Installations` | `12.5.0.4` |
-| `PerformanceMonitoring` | `12.5.0.4` |
-| `RemoteConfig` | `12.5.0.4` |
-| `Storage` | `12.5.0.4` |
+| `ABTesting` | `12.6.0` |
+| `Analytics` | `12.6.0` |
+| `AppCheck` | `12.6.0` |
+| `AppDistribution` | `12.6.0` |
+| `Auth` | `12.6.0` |
+| `CloudFirestore` | `12.6.0` |
+| `CloudFunctions` | `12.6.0` |
+| `CloudMessaging` | `12.6.0` |
+| `Core` | `12.6.0` |
+| `Crashlytics` | `12.6.0` |
+| `Database` | `12.6.0` |
+| `InAppMessaging` | `12.6.0` |
+| `Installations` | `12.6.0` |
+| `PerformanceMonitoring` | `12.6.0` |
+| `RemoteConfig` | `12.6.0` |
+| `Storage` | `12.6.0` |
 
 #### Google packages (`AdamE.Google.iOS.*`)
 
@@ -110,7 +114,7 @@ These packages are usually consumed transitively rather than referenced directly
 | Package | Version |
 | --- | --- |
 | `AppCheckCore` | `11.2.0` |
-| `GoogleAppMeasurement` | `12.5.0.4` |
+| `GoogleAppMeasurement` | `12.6.0` |
 | `GoogleDataTransport` | `10.1.0.5` |
 | `GoogleUtilities` | `8.1.0.3` |
 | `Nanopb` | `3.30910.0.5` |
@@ -134,8 +138,6 @@ These packages are still published on nuget.org, but they are not part of the cu
 
 These projects exist in this repository, but I could not confirm current nuget.org packages for them under the `AdamE.*` package names:
 
-- `AdamE.Firebase.iOS.AppDistribution` is present in `source/` at `8.10.0`, but is not currently published on nuget.org.
-- `AdamE.Firebase.iOS.InAppMessaging` is present in `source/` at `8.10.0.3`, but is not currently published on nuget.org.
 - `AdamE.Google.iOS.Analytics`, `Cast`, `MobileAds`, `TagManager`, and `UserMessagingPlatform` are present in `source/`, but are not listed in the current nuget.org package set.
 - `AdamE.MLKit.iOS.DigitalInkRecognition`, `FaceDetection`, `ImageLabeling`, and `ObjectDetection` are present in `source/` at `1.5.0`, but are not currently published on nuget.org.
 - `AdamE.MLKit.iOS.TextRecognition`, `TextRecognition.Chinese`, `TextRecognition.Devanagari`, `TextRecognition.Japanese`, and `TextRecognition.Korean` are present in `source/` at `1.0.0.3`, but are not currently published on nuget.org.

--- a/docs/Firebase/NuGet/ABTesting.md
+++ b/docs/Firebase/NuGet/ABTesting.md
@@ -121,9 +121,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Analytics.md
+++ b/docs/Firebase/NuGet/Analytics.md
@@ -104,9 +104,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/AppCheck.md
+++ b/docs/Firebase/NuGet/AppCheck.md
@@ -106,9 +106,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/AppDistribution.md
+++ b/docs/Firebase/NuGet/AppDistribution.md
@@ -111,9 +111,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Auth.md
+++ b/docs/Firebase/NuGet/Auth.md
@@ -114,9 +114,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudFirestore.md
+++ b/docs/Firebase/NuGet/CloudFirestore.md
@@ -116,9 +116,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudFunctions.md
+++ b/docs/Firebase/NuGet/CloudFunctions.md
@@ -110,9 +110,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudMessaging.md
+++ b/docs/Firebase/NuGet/CloudMessaging.md
@@ -112,9 +112,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Core.md
+++ b/docs/Firebase/NuGet/Core.md
@@ -104,9 +104,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Crashlytics.md
+++ b/docs/Firebase/NuGet/Crashlytics.md
@@ -109,9 +109,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Database.md
+++ b/docs/Firebase/NuGet/Database.md
@@ -107,9 +107,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/InAppMessaging.md
+++ b/docs/Firebase/NuGet/InAppMessaging.md
@@ -102,9 +102,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Installations.md
+++ b/docs/Firebase/NuGet/Installations.md
@@ -112,9 +112,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/PerformanceMonitoring.md
+++ b/docs/Firebase/NuGet/PerformanceMonitoring.md
@@ -109,9 +109,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/RemoteConfig.md
+++ b/docs/Firebase/NuGet/RemoteConfig.md
@@ -114,9 +114,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Storage.md
+++ b/docs/Firebase/NuGet/Storage.md
@@ -115,9 +115,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0.3" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0.2" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0.5" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
 </ItemGroup>
 ```
 

--- a/samples/Firebase/AppCheck/AppCheckSample/AppCheckSample.NuGet.csproj
+++ b/samples/Firebase/AppCheck/AppCheckSample/AppCheckSample.NuGet.csproj
@@ -68,8 +68,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Build.Download" Version="0.11.1" />
-    <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.5.0.4" />
-    <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="12.5.0.4" />
-    <PackageReference Include="AdamE.Firebase.iOS.Installations" Version="12.5.0.4" />
+    <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+    <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="12.6.0" />
+    <PackageReference Include="AdamE.Firebase.iOS.Installations" Version="12.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- update the README Firebase package status for the published 12.6.0 release line
- move AppDistribution and InAppMessaging into the published Firebase package set
- normalize Firebase NuGet documentation examples to the actual published 12.6.0 versions
- update the AppCheck NuGet sample references to 12.6.0

## Validation
- `rg "12\\.5\\.0\\.4|12\\.6\\.0\\.[0-9]|AppDistribution.*not currently published|InAppMessaging.*not currently published" Readme.md docs/Firebase/NuGet samples/Firebase/AppCheck`
- `git diff --check`
- `git ls-remote --tags origin v12.6.0`
- `gh release view v12.6.0`
- nuget.org flat-container checks for all 16 Firebase 12.6.0 packages plus GoogleAppMeasurement 12.6.0