### PR TITLE
[codex] Update Cake tooling

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,11 +3,10 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.5",
+      "version": "6.1.0",
       "commands": [
         "dotnet-cake"
       ]
     }
   }
 }
-

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,3 @@
-#addin nuget:?package=Cake.XCode&version=4.2.0
-#addin nuget:?package=Cake.Xamarin.Build&version=4.1.1
-#addin nuget:?package=Cake.FileHelpers&version=3.2.0
-
 #load "poco.cake"
 #load "components.cake"
 #load "common.cake"
@@ -55,9 +51,6 @@ void BuildCake (string target)
 	// Run the script from the subfolder
 	CakeExecuteScript ("./build.cake", cakeSettings);
 }
-
-// From Cake.Xamarin.Build, dumps out versions of things
-// LogSystemInfo ();
 
 Setup (context =>
 {
@@ -175,9 +168,9 @@ Task ("libs")
 	.IsDependentOn("ci-setup")
 	.Does(() =>
 {
-	var dotNetCoreBuildSettings = new DotNetCoreBuildSettings { 
+	var dotNetBuildSettings = new DotNetBuildSettings {
 		Configuration = "Release",
-		Verbosity = DotNetCoreVerbosity.Diagnostic,
+		Verbosity = DotNetVerbosity.Diagnostic,
 		NoRestore = false
 	};
 	
@@ -185,7 +178,7 @@ Task ("libs")
 	foreach (var artifact in ARTIFACTS_TO_BUILD) {
 		var csprojPath = $"./source/{artifact.ComponentGroup}/{artifact.CsprojName}/{artifact.CsprojName}.csproj";
 		Information ($"Building: {csprojPath}");
-		DotNetCoreBuild(csprojPath, dotNetCoreBuildSettings);
+		DotNetBuild(csprojPath, dotNetBuildSettings);
 	}
 });
 
@@ -193,14 +186,14 @@ Task ("samples")
 	.IsDependentOn("libs")
 	.Does(() =>
 {
-	var msBuildSettings = new DotNetCoreMSBuildSettings ();
+	var msBuildSettings = new DotNetMSBuildSettings ();
 	msBuildSettings.Properties ["Platform"] = new [] { "iPhoneSimulator" };
 	msBuildSettings.Properties ["RuntimeIdentifier"] = new [] { GetDefaultiOSSimulatorRuntimeIdentifier () };
 	msBuildSettings.Properties ["EnableCodeSigning"] = new [] { "false" };
 
-	var dotNetCoreBuildSettings = new DotNetCoreBuildSettings { 
+	var dotNetBuildSettings = new DotNetBuildSettings {
 		Configuration = "Release",
-		Verbosity = DotNetCoreVerbosity.Diagnostic,
+		Verbosity = DotNetVerbosity.Diagnostic,
 		NoRestore = false,
 		MSBuildSettings = msBuildSettings
 	};
@@ -213,7 +206,7 @@ Task ("samples")
 			var samplePath = $"./samples/{artifact.ComponentGroup}/{sample}/{sample}.csproj";
 			if (FileExists(samplePath)) {
 				Information ($"Building sample: {samplePath}");
-				DotNetCoreBuild(samplePath, dotNetCoreBuildSettings);
+				DotNetBuild(samplePath, dotNetBuildSettings);
 			}
 		}
 	}
@@ -225,19 +218,19 @@ Task ("nuget")
 {
 	EnsureDirectoryExists("./output/");
 
-	var dotNetCorePackSettings = new DotNetCorePackSettings {
+	var dotNetPackSettings = new DotNetPackSettings {
 		Configuration = "Release",
 		NoRestore = true,
 		NoBuild = true,
 		OutputDirectory = "./output/",
-		Verbosity = DotNetCoreVerbosity.Diagnostic,
+		Verbosity = DotNetVerbosity.Diagnostic,
 	};
 
 	// Pack each artifact's csproj directly
 	foreach (var artifact in ARTIFACTS_TO_BUILD) {
 		var csprojPath = $"./source/{artifact.ComponentGroup}/{artifact.CsprojName}/{artifact.CsprojName}.csproj";
 		Information ($"Packing: {csprojPath}");
-		DotNetCorePack(csprojPath, dotNetCorePackSettings);
+		DotNetPack(csprojPath, dotNetPackSettings);
 	}
 });
 

--- a/common.cake
+++ b/common.cake
@@ -13,6 +13,122 @@ var PODFILE_END = new [] {
 	"end",
 };
 
+class XCodeBuildSettings
+{
+	public bool Archive { get; set; }
+	public string ArchivePath { get; set; }
+	public string Arch { get; set; }
+	public Dictionary<string, string> BuildSettings { get; set; }
+	public bool Clean { get; set; }
+	public string Configuration { get; set; }
+	public string Project { get; set; }
+	public string Scheme { get; set; }
+	public string Sdk { get; set; }
+	public string Target { get; set; }
+	public bool Verbose { get; set; }
+}
+
+string QuoteArgument (string value)
+	=> "\"" + value.Replace ("\"", "\\\"") + "\"";
+
+void ThrowIfProcessFailed (string tool, int exitCode)
+{
+	if (exitCode != 0)
+		throw new Exception ($"{tool} failed with exit code {exitCode}.");
+}
+
+void CocoaPodRepoUpdate ()
+{
+	var args = new ProcessArgumentBuilder ();
+	args.Append ("repo");
+	args.Append ("update");
+
+	ThrowIfProcessFailed ("pod repo update", StartProcess ("pod", new ProcessSettings { Arguments = args }));
+}
+
+void CocoaPodInstall (DirectoryPath projectDirectory)
+{
+	var args = new ProcessArgumentBuilder ();
+	args.Append ("install");
+	args.Append ("--project-directory=" + QuoteArgument (MakeAbsolute (projectDirectory).FullPath));
+
+	ThrowIfProcessFailed ("pod install", StartProcess ("pod", new ProcessSettings { Arguments = args }));
+}
+
+void XCodeBuild (XCodeBuildSettings settings)
+{
+	var args = new ProcessArgumentBuilder ();
+
+	if (settings.Verbose)
+		args.Append ("-verbose");
+	if (!string.IsNullOrWhiteSpace (settings.Project))
+		args.Append ($"-project {QuoteArgument (settings.Project)}");
+	if (!string.IsNullOrWhiteSpace (settings.Target))
+		args.Append ($"-target {QuoteArgument (settings.Target)}");
+	if (!string.IsNullOrWhiteSpace (settings.Scheme))
+		args.Append ($"-scheme {QuoteArgument (settings.Scheme)}");
+	if (!string.IsNullOrWhiteSpace (settings.Configuration))
+		args.Append ($"-configuration {QuoteArgument (settings.Configuration)}");
+	if (!string.IsNullOrWhiteSpace (settings.Arch))
+		args.Append ($"-arch {QuoteArgument (settings.Arch)}");
+	if (!string.IsNullOrWhiteSpace (settings.Sdk))
+		args.Append ($"-sdk {QuoteArgument (settings.Sdk)}");
+	if (!string.IsNullOrWhiteSpace (settings.ArchivePath))
+		args.Append ($"-archivePath {QuoteArgument (MakeAbsolute ((DirectoryPath)settings.ArchivePath).FullPath)}");
+
+	args.Append (settings.Archive ? "archive" : "build");
+
+	if (settings.Clean)
+		args.Append ("clean");
+
+	if (settings.BuildSettings != null)
+		foreach (var buildSetting in settings.BuildSettings)
+			args.Append ($"{buildSetting.Key}={buildSetting.Value}");
+
+	ThrowIfProcessFailed ("xcodebuild", StartProcess ("xcodebuild", new ProcessSettings { Arguments = args }));
+}
+
+void RunLipoCreate (DirectoryPath workingDirectory, string output, params FilePath[] inputs)
+	=> RunLipoCreate (workingDirectory, (FilePath)output, inputs);
+
+void RunLipoCreate (DirectoryPath workingDirectory, FilePath output, params FilePath[] inputs)
+{
+	if (!IsRunningOnUnix ()) {
+		Warning("{0} is not available on the current platform.", "lipo");
+		return;
+	}
+
+	var args = new ProcessArgumentBuilder ();
+	args.Append ("-create");
+	args.Append ("-output");
+	args.AppendQuoted (output.ToString ());
+
+	foreach (var input in inputs)
+		args.AppendQuoted (input.ToString ());
+
+	ThrowIfProcessFailed ("lipo", StartProcess ("lipo", new ProcessSettings {
+		Arguments = args,
+		WorkingDirectory = workingDirectory
+	}));
+}
+
+void FileWriteLines (FilePath path, string[] lines)
+{
+	System.IO.File.WriteAllLines (MakeAbsolute (path).FullPath, lines);
+}
+
+void ReplaceTextInFiles (string glob, string oldValue, string newValue)
+{
+	foreach (var file in GetFiles (glob)) {
+		var path = MakeAbsolute (file).FullPath;
+		var text = System.IO.File.ReadAllText (path);
+		var updatedText = text.Replace (oldValue, newValue);
+
+		if (!string.Equals (text, updatedText, StringComparison.Ordinal))
+			System.IO.File.WriteAllText (path, updatedText);
+	}
+}
+
 void CopyDirectoryWithSymlinks (DirectoryPath source, DirectoryPath destination)
 {
 	if (DirectoryExists (destination)) {

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -8,7 +8,7 @@ This repo builds .NET iOS/macOS bindings and NuGet packages using Cake.
 - Xcode (matching the installed iOS workload requirements)
 - CocoaPods (`pod`)
 
-Restore the local Cake tool (any version `< 1.0` should work):
+Restore the local Cake tool from the checked-in .NET tool manifest:
 
 ```sh
 dotnet tool restore


### PR DESCRIPTION
## Summary

- Bump the local Cake tool manifest from 0.38.5 to 6.1.0.
- Replace deprecated Cake addins with local wrappers for CocoaPods, xcodebuild, lipo, and text/file helpers.
- Move build and pack aliases from `DotNetCore*` to modern `DotNet*` APIs.
- Update build docs to restore the checked-in tool manifest instead of recommending pre-1.0 Cake.

## Validation

- `dotnet tool restore`
- `dotnet tool run dotnet-cake -- --target=clean --dryrun --verbosity=quiet`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Google.SignIn --dryrun --verbosity=quiet`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Google.SignIn`

The real `Google.SignIn` pack run produced 5 NuGet packages and completed `externals`, `libs`, and `nuget` successfully.