### PR TITLE
[codex] Prepare Firebase 12.7 bindings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ If your project targets multiple platforms, keep these packages inside Apple-onl
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -74,7 +74,7 @@ Archiving can still be more reliable on macOS or from the command line.
 
 The lists below reflect what is currently published on [nuget.org](https://www.nuget.org/profiles/adamessenmacher) under the `adamessenmacher` owner profile. That is intentionally different from the repo state in [`components.cake`](components.cake): the repo can contain projects or version bumps that have not been published yet.
 
-Firebase `12.6.0` is the current published Firebase package line.
+Firebase `12.7.0` is the current published Firebase package line.
 
 ### Currently published on nuget.org
 
@@ -82,22 +82,22 @@ Firebase `12.6.0` is the current published Firebase package line.
 
 | Package | Version |
 | --- | --- |
-| `ABTesting` | `12.6.0` |
-| `Analytics` | `12.6.0` |
-| `AppCheck` | `12.6.0` |
-| `AppDistribution` | `12.6.0` |
-| `Auth` | `12.6.0` |
-| `CloudFirestore` | `12.6.0` |
-| `CloudFunctions` | `12.6.0` |
-| `CloudMessaging` | `12.6.0` |
-| `Core` | `12.6.0` |
-| `Crashlytics` | `12.6.0` |
-| `Database` | `12.6.0` |
-| `InAppMessaging` | `12.6.0` |
-| `Installations` | `12.6.0` |
-| `PerformanceMonitoring` | `12.6.0` |
-| `RemoteConfig` | `12.6.0` |
-| `Storage` | `12.6.0` |
+| `ABTesting` | `12.7.0` |
+| `Analytics` | `12.7.0` |
+| `AppCheck` | `12.7.0` |
+| `AppDistribution` | `12.7.0` |
+| `Auth` | `12.7.0` |
+| `CloudFirestore` | `12.7.0` |
+| `CloudFunctions` | `12.7.0` |
+| `CloudMessaging` | `12.7.0` |
+| `Core` | `12.7.0` |
+| `Crashlytics` | `12.7.0` |
+| `Database` | `12.7.0` |
+| `InAppMessaging` | `12.7.0` |
+| `Installations` | `12.7.0` |
+| `PerformanceMonitoring` | `12.7.0` |
+| `RemoteConfig` | `12.7.0` |
+| `Storage` | `12.7.0` |
 
 #### Google packages (`AdamE.Google.iOS.*`)
 
@@ -114,7 +114,7 @@ These packages are usually consumed transitively rather than referenced directly
 | Package | Version |
 | --- | --- |
 | `AppCheckCore` | `11.2.0` |
-| `GoogleAppMeasurement` | `12.6.0` |
+| `GoogleAppMeasurement` | `12.7.0` |
 | `GoogleDataTransport` | `10.1.0.5` |
 | `GoogleUtilities` | `8.1.0.3` |
 | `Nanopb` | `3.30910.0.5` |

--- a/components.cake
+++ b/components.cake
@@ -1,20 +1,20 @@
 // Firebase artifacts available to be built. These artifacts generate NuGets.
-Artifact FIREBASE_AB_TESTING_ARTIFACT              = new Artifact ("Firebase.ABTesting",              "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "ABTesting");
-Artifact FIREBASE_ANALYTICS_ARTIFACT               = new Artifact ("Firebase.Analytics",              "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Analytics");
-Artifact FIREBASE_AUTH_ARTIFACT                    = new Artifact ("Firebase.Auth",                   "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Auth");
-Artifact FIREBASE_CLOUD_FIRESTORE_ARTIFACT         = new Artifact ("Firebase.CloudFirestore",         "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFirestore");
-Artifact FIREBASE_CLOUD_FUNCTIONS_ARTIFACT         = new Artifact ("Firebase.CloudFunctions",         "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFunctions");
-Artifact FIREBASE_CLOUD_MESSAGING_ARTIFACT         = new Artifact ("Firebase.CloudMessaging",         "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudMessaging");
-Artifact FIREBASE_CORE_ARTIFACT                    = new Artifact ("Firebase.Core",                   "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Core");
-Artifact FIREBASE_CRASHLYTICS_ARTIFACT             = new Artifact ("Firebase.Crashlytics",            "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Crashlytics");
-Artifact FIREBASE_DATABASE_ARTIFACT                = new Artifact ("Firebase.Database",               "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Database");
-Artifact FIREBASE_IN_APP_MESSAGING_ARTIFACT        = new Artifact ("Firebase.InAppMessaging",         "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "InAppMessaging");
-Artifact FIREBASE_INSTALLATIONS_ARTIFACT           = new Artifact ("Firebase.Installations",          "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Installations");
-Artifact FIREBASE_PERFORMANCE_MONITORING_ARTIFACT  = new Artifact ("Firebase.PerformanceMonitoring",  "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "PerformanceMonitoring");
-Artifact FIREBASE_REMOTE_CONFIG_ARTIFACT           = new Artifact ("Firebase.RemoteConfig",           "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "RemoteConfig");
-Artifact FIREBASE_STORAGE_ARTIFACT                 = new Artifact ("Firebase.Storage",                "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "Storage");
-Artifact FIREBASE_APP_DISTRIBUTION_ARTIFACT        = new Artifact ("Firebase.AppDistribution",        "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppDistribution");
-Artifact FIREBASE_APP_CHECK_ARTIFACT               = new Artifact ("Firebase.AppCheck",               "12.6.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppCheck");
+Artifact FIREBASE_AB_TESTING_ARTIFACT              = new Artifact ("Firebase.ABTesting",              "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "ABTesting");
+Artifact FIREBASE_ANALYTICS_ARTIFACT               = new Artifact ("Firebase.Analytics",              "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Analytics");
+Artifact FIREBASE_AUTH_ARTIFACT                    = new Artifact ("Firebase.Auth",                   "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Auth");
+Artifact FIREBASE_CLOUD_FIRESTORE_ARTIFACT         = new Artifact ("Firebase.CloudFirestore",         "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFirestore");
+Artifact FIREBASE_CLOUD_FUNCTIONS_ARTIFACT         = new Artifact ("Firebase.CloudFunctions",         "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFunctions");
+Artifact FIREBASE_CLOUD_MESSAGING_ARTIFACT         = new Artifact ("Firebase.CloudMessaging",         "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudMessaging");
+Artifact FIREBASE_CORE_ARTIFACT                    = new Artifact ("Firebase.Core",                   "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Core");
+Artifact FIREBASE_CRASHLYTICS_ARTIFACT             = new Artifact ("Firebase.Crashlytics",            "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Crashlytics");
+Artifact FIREBASE_DATABASE_ARTIFACT                = new Artifact ("Firebase.Database",               "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Database");
+Artifact FIREBASE_IN_APP_MESSAGING_ARTIFACT        = new Artifact ("Firebase.InAppMessaging",         "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "InAppMessaging");
+Artifact FIREBASE_INSTALLATIONS_ARTIFACT           = new Artifact ("Firebase.Installations",          "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Installations");
+Artifact FIREBASE_PERFORMANCE_MONITORING_ARTIFACT  = new Artifact ("Firebase.PerformanceMonitoring",  "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "PerformanceMonitoring");
+Artifact FIREBASE_REMOTE_CONFIG_ARTIFACT           = new Artifact ("Firebase.RemoteConfig",           "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "RemoteConfig");
+Artifact FIREBASE_STORAGE_ARTIFACT                 = new Artifact ("Firebase.Storage",                "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Storage");
+Artifact FIREBASE_APP_DISTRIBUTION_ARTIFACT        = new Artifact ("Firebase.AppDistribution",        "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppDistribution");
+Artifact FIREBASE_APP_CHECK_ARTIFACT               = new Artifact ("Firebase.AppCheck",               "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppCheck");
 
 // Google artifacts available to be built. These artifacts generate NuGets.
 Artifact GOOGLE_ANALYTICS_ARTIFACT                 = new Artifact ("Google.Analytics",                "3.20.0.2",  "15.0", ComponentGroup.Google, csprojName: "Analytics");
@@ -27,7 +27,7 @@ Artifact GOOGLE_APP_CHECK_CORE_ARTIFACT            = new Artifact ("Google.AppCh
 Artifact GOOGLE_SIGN_IN_ARTIFACT                   = new Artifact ("Google.SignIn",                   "9.0.0.0",   "15.0", ComponentGroup.Google, csprojName: "SignIn");
 Artifact GOOGLE_TAG_MANAGER_ARTIFACT               = new Artifact ("Google.TagManager",               "7.4.0.2",   "15.0", ComponentGroup.Google, csprojName: "TagManager");
 
-Artifact GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT    = new Artifact ("Google.AppMeasurement",           "12.6.0",      "15.0", ComponentGroup.Google, csprojName: "GoogleAppMeasurement");
+Artifact GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT    = new Artifact ("Google.AppMeasurement",           "12.7.0",      "15.0", ComponentGroup.Google, csprojName: "GoogleAppMeasurement");
 Artifact GOOGLE_PROMISES_OBJC_ARTIFACT             = new Artifact ("Google.PromisesObjC",             "2.4.0.5",     "15.0", ComponentGroup.Google, csprojName: "PromisesObjC");
 Artifact GOOGLE_GTM_SESSION_FETCHER_ARTIFACT       = new Artifact ("Google.GTMSessionFetcher",        "3.5.0.5",     "15.0", ComponentGroup.Google, csprojName: "GTMSessionFetcher");
 Artifact GOOGLE_NANOPB_ARTIFACT                    = new Artifact ("Google.Nanopb",                   "3.30910.0.5", "15.0", ComponentGroup.Google, csprojName: "Nanopb");
@@ -151,68 +151,68 @@ void SetArtifactsPodSpecs ()
 {
 	// Firebase components
 	FIREBASE_AB_TESTING_ARTIFACT.PodSpecs = new [] { 
-		PodSpec.Create ("FirebaseABTesting", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseABTesting", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_ANALYTICS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAnalytics", "12.6.0")
+		PodSpec.Create ("FirebaseAnalytics", "12.7.0")
 	};
 	FIREBASE_AUTH_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAuth",     "12.6.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseAuth",     "12.7.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("RecaptchaInterop", "101.0.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CLOUD_FIRESTORE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseFirestore",         "12.6.0",       frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseFirestoreInternal", "12.6.0",       frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseFirestore",         "12.7.0",       frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseFirestoreInternal", "12.7.0",       frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("BoringSSL-GRPC",            "0.0.37",       frameworkSource: FrameworkSource.Pods, frameworkName: "openssl_grpc"),
 		PodSpec.Create ("gRPC-Core",                 "1.69.0",       frameworkSource: FrameworkSource.Pods, frameworkName: "grpc"),
 		PodSpec.Create ("gRPC-C++",                  "1.69.0",       frameworkSource: FrameworkSource.Pods, frameworkName: "grpcpp"),
 		PodSpec.Create ("abseil",                    "1.20240722.0", frameworkSource: FrameworkSource.Pods, frameworkName: "absl", subSpecs: new [] { "algorithm", "base", "memory", "meta", "strings", "time", "types" }),
 	};
 	FIREBASE_CLOUD_FUNCTIONS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseFunctions", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseFunctions", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CLOUD_MESSAGING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseMessaging", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseMessaging", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CORE_ARTIFACT.PodSpecs = new [] {
-	    PodSpec.Create ("FirebaseAppCheckInterop",     "12.6.0", frameworkSource: FrameworkSource.Pods),
-	    PodSpec.Create ("FirebaseAuthInterop",         "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCore",                "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCoreExtension",       "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCoreInternal",        "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseMessagingInterop",    "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseSharedSwift",         "12.6.0", frameworkSource: FrameworkSource.Pods),
+	    PodSpec.Create ("FirebaseAppCheckInterop",     "12.7.0", frameworkSource: FrameworkSource.Pods),
+	    PodSpec.Create ("FirebaseAuthInterop",         "12.7.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCore",                "12.7.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCoreExtension",       "12.7.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCoreInternal",        "12.7.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseMessagingInterop",    "12.7.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.7.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseSharedSwift",         "12.7.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("PromisesSwift",               "2.4.0",  frameworkSource: FrameworkSource.Pods, frameworkName: "Promises", targetName: "PromisesSwift"),
 		PodSpec.Create ("leveldb-library",             "1.22.6", frameworkSource: FrameworkSource.Pods, frameworkName: "leveldb"),
 	};
 	FIREBASE_CRASHLYTICS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseCrashlytics", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseCrashlytics", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_DATABASE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseDatabase", "12.6.0", frameworkSource: FrameworkSource.Pods)		
+		PodSpec.Create ("FirebaseDatabase", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_IN_APP_MESSAGING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("Firebase", "12.6.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
+		PodSpec.Create ("Firebase", "12.7.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
 	};
 	FIREBASE_INSTALLATIONS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseInstallations", "12.6.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseSessions",      "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseInstallations", "12.7.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseSessions",      "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_PERFORMANCE_MONITORING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebasePerformance", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebasePerformance", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_REMOTE_CONFIG_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseRemoteConfig", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseRemoteConfig", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_STORAGE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseStorage", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseStorage", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_APP_DISTRIBUTION_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("Firebase", "12.6.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseAppDistribution", targetName: "FirebaseAppDistribution", subSpecs: new [] { "AppDistribution" })
+		PodSpec.Create ("Firebase", "12.7.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseAppDistribution", targetName: "FirebaseAppDistribution", subSpecs: new [] { "AppDistribution" })
 	};
 	FIREBASE_APP_CHECK_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAppCheck", "12.6.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseAppCheck", "12.7.0", frameworkSource: FrameworkSource.Pods)
 	};
 
 	// Google components
@@ -246,7 +246,7 @@ void SetArtifactsPodSpecs ()
 		PodSpec.Create ("GoogleTagManager", "7.4.0")
 	};
     GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT.PodSpecs = new [] {
-        PodSpec.Create ("GoogleAppMeasurement", "12.6.0")
+        PodSpec.Create ("GoogleAppMeasurement", "12.7.0")
     };
 	GOOGLE_PROMISES_OBJC_ARTIFACT.PodSpecs = new [] {
 	    PodSpec.Create ("PromisesObjC", "2.4.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FBLPromises", targetName: "PromisesObjC"),

--- a/docs/Firebase/NuGet/ABTesting.md
+++ b/docs/Firebase/NuGet/ABTesting.md
@@ -46,7 +46,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.ABTesting" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.ABTesting" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -121,9 +121,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Analytics.md
+++ b/docs/Firebase/NuGet/Analytics.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -104,9 +104,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/AppCheck.md
+++ b/docs/Firebase/NuGet/AppCheck.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -106,9 +106,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/AppDistribution.md
+++ b/docs/Firebase/NuGet/AppDistribution.md
@@ -46,7 +46,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.AppDistribution" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.AppDistribution" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -88,7 +88,7 @@ if (!appDistribution.IsTesterSignedIn)
 - `AdamE.Firebase.iOS.Core` - Firebase app initialization.
 - `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
 
-This package is part of the Firebase `12.6.0` package line. Firebase's `12.6.0` aggregate CocoaPods spec exposes App Distribution through `Firebase/AppDistribution`, which resolves the native `FirebaseAppDistribution` pod at `12.6.0-beta`.
+This package is part of the Firebase `12.7.0` package line. Firebase's `12.7.0` aggregate CocoaPods spec exposes App Distribution through `Firebase/AppDistribution`, which resolves the native `FirebaseAppDistribution` pod at `12.7.0-beta`.
 
 ## Firebase app configuration
 
@@ -111,9 +111,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Auth.md
+++ b/docs/Firebase/NuGet/Auth.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -114,9 +114,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudFirestore.md
+++ b/docs/Firebase/NuGet/CloudFirestore.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -116,9 +116,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudFunctions.md
+++ b/docs/Firebase/NuGet/CloudFunctions.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -110,9 +110,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudMessaging.md
+++ b/docs/Firebase/NuGet/CloudMessaging.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -112,9 +112,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Core.md
+++ b/docs/Firebase/NuGet/Core.md
@@ -46,7 +46,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -104,9 +104,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Crashlytics.md
+++ b/docs/Firebase/NuGet/Crashlytics.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -109,9 +109,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Database.md
+++ b/docs/Firebase/NuGet/Database.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Database" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Database" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -107,9 +107,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/InAppMessaging.md
+++ b/docs/Firebase/NuGet/InAppMessaging.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.InAppMessaging" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.InAppMessaging" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -79,7 +79,7 @@ inAppMessaging.TriggerEvent("purchase_complete");
 - `AdamE.Firebase.iOS.ABTesting` - package metadata references Firebase A/B Testing for campaign experiment handling.
 - `AdamE.Firebase.iOS.Analytics` - commonly used with In-App Messaging campaign triggers and measurement.
 
-This package is part of the Firebase `12.6.0` package line in this repository. Firebase's aggregate `Firebase/InAppMessaging` `12.6.0` CocoaPods subspec resolves the native `FirebaseInAppMessaging` `12.6.0-beta` pod.
+This package is part of the Firebase `12.7.0` package line in this repository. Firebase's aggregate `Firebase/InAppMessaging` `12.7.0` CocoaPods subspec resolves the native `FirebaseInAppMessaging` `12.7.0-beta` pod.
 
 ## Firebase app configuration
 
@@ -102,9 +102,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Installations.md
+++ b/docs/Firebase/NuGet/Installations.md
@@ -46,7 +46,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Installations" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Installations" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -112,9 +112,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/PerformanceMonitoring.md
+++ b/docs/Firebase/NuGet/PerformanceMonitoring.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.PerformanceMonitoring" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.PerformanceMonitoring" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -109,9 +109,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/RemoteConfig.md
+++ b/docs/Firebase/NuGet/RemoteConfig.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -114,9 +114,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Storage.md
+++ b/docs/Firebase/NuGet/Storage.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="12.7.0" />
 </ItemGroup>
 ```
 
@@ -115,9 +115,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.6.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.6.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
 </ItemGroup>
 ```
 

--- a/scripts/FirebaseBindingAudit/BindingSurfaceCoverage.cs
+++ b/scripts/FirebaseBindingAudit/BindingSurfaceCoverage.cs
@@ -10,7 +10,7 @@ namespace FirebaseBindingAudit;
 
 internal static class FirebasePackageVersions
 {
-    public const string DefaultFirebasePackageVersion = "12.6.0";
+    public const string DefaultFirebasePackageVersion = "12.7.0";
 }
 
 internal sealed class BindingSurfaceCoverageManifest

--- a/source/Firebase/ABTesting/ABTesting.csproj
+++ b/source/Firebase/ABTesting/ABTesting.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.ABTesting</RootNamespace>
     <AssemblyName>Firebase.ABTesting</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Analytics/Analytics.csproj
+++ b/source/Firebase/Analytics/Analytics.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Analytics</RootNamespace>
     <AssemblyName>Firebase.Analytics</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProcessEnums>true</ProcessEnums>
@@ -28,7 +28,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />
@@ -57,7 +57,7 @@
     <ObjcBindingApiDefinition Include="Enums.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AdamE.Google.iOS.GoogleAppMeasurement" Version="12.6.0" />
+    <PackageReference Include="AdamE.Google.iOS.GoogleAppMeasurement" Version="12.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" PrivateAssets="None" />

--- a/source/Firebase/Analytics/Analytics.targets
+++ b/source/Firebase/Analytics/Analytics.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=12.6.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
+    <_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/AppCheck/AppCheck.csproj
+++ b/source/Firebase/AppCheck/AppCheck.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.AppCheck</RootNamespace>
     <AssemblyName>Firebase.AppCheck</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/AppCheck/AppCheck.targets
+++ b/source/Firebase/AppCheck/AppCheck.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseAppCheckAssemblyName>Firebase.AppCheck, Version=12.6.0, Culture=neutral, PublicKeyToken=null</_FirebaseAppCheckAssemblyName>
+    <_FirebaseAppCheckAssemblyName>Firebase.AppCheck, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_FirebaseAppCheckAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/AppDistribution/AppDistribution.csproj
+++ b/source/Firebase/AppDistribution/AppDistribution.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.AppDistribution</RootNamespace>
     <AssemblyName>Firebase.AppDistribution</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Auth/Auth.csproj
+++ b/source/Firebase/Auth/Auth.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Auth</RootNamespace>
     <AssemblyName>Firebase.Auth</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudFirestore/CloudFirestore.csproj
+++ b/source/Firebase/CloudFirestore/CloudFirestore.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudFirestore</RootNamespace>
     <AssemblyName>Firebase.CloudFirestore</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudFunctions/CloudFunctions.csproj
+++ b/source/Firebase/CloudFunctions/CloudFunctions.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudFunctions</RootNamespace>
     <AssemblyName>Firebase.CloudFunctions</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudMessaging/CloudMessaging.csproj
+++ b/source/Firebase/CloudMessaging/CloudMessaging.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudMessaging</RootNamespace>
     <AssemblyName>Firebase.CloudMessaging</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Core</RootNamespace>
     <AssemblyName>Firebase.Core</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Core/Core.targets
+++ b/source/Firebase/Core/Core.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseCoreAssemblyName>Firebase.Core, Version=12.6.0, Culture=neutral, PublicKeyToken=null</_FirebaseCoreAssemblyName>
+    <_FirebaseCoreAssemblyName>Firebase.Core, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_FirebaseCoreAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/Crashlytics/Crashlytics.csproj
+++ b/source/Firebase/Crashlytics/Crashlytics.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Crashlytics</RootNamespace>
     <AssemblyName>Firebase.Crashlytics</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Crashlytics/Crashlytics.targets
+++ b/source/Firebase/Crashlytics/Crashlytics.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <_FirebaseCrashlyticsAssemblyName>Firebase.Crashlytics, Version=12.6.0, Culture=neutral, PublicKeyToken=null</_FirebaseCrashlyticsAssemblyName>
-    <_FirebaseCrashlyticsItemsFolder>FCrshlytcs-12.6.0</_FirebaseCrashlyticsItemsFolder>
+    <_FirebaseCrashlyticsAssemblyName>Firebase.Crashlytics, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_FirebaseCrashlyticsAssemblyName>
+    <_FirebaseCrashlyticsItemsFolder>FCrshlytcs-12.7.0</_FirebaseCrashlyticsItemsFolder>
     <_FirebaseCrashlyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseCrashlyticsItemsFolder)\</_FirebaseCrashlyticsSDKBaseFolder>
     <!-- Requires a file extension, otherwise XDB will complain  -->
     <_FirebaseScriptName>upload-symbols.sh</_FirebaseScriptName>
@@ -22,7 +22,7 @@
   <ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
     <XamarinBuildDownload Include="$(_FirebaseCrashlyticsItemsFolder)">
       <!-- To upgrade, change commit id from the appropriate tag: https://github.com/firebase/firebase-ios-sdk/tags-->
-      <Url>https://raw.githubusercontent.com/firebase/firebase-ios-sdk/087bb95235f676c1a37e928769a5b6645dcbd325/Crashlytics/upload-symbols</Url>
+      <Url>https://raw.githubusercontent.com/firebase/firebase-ios-sdk/45210bd1ea695779e6de016ab00fea8c0b7eb2ef/Crashlytics/upload-symbols</Url>
       <ToFile>$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)</ToFile>
       <Kind>Uncompressed</Kind>
     </XamarinBuildDownload>

--- a/source/Firebase/Database/Database.csproj
+++ b/source/Firebase/Database/Database.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Database</RootNamespace>
     <AssemblyName>Firebase.Database</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/InAppMessaging/InAppMessaging.csproj
+++ b/source/Firebase/InAppMessaging/InAppMessaging.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.InAppMessaging</RootNamespace>
     <AssemblyName>Firebase.InAppMessaging</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Installations/Installations.csproj
+++ b/source/Firebase/Installations/Installations.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Installations</RootNamespace>
     <AssemblyName>Firebase.Installations</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
+++ b/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.PerformanceMonitoring</RootNamespace>
     <AssemblyName>Firebase.PerformanceMonitoring</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/RemoteConfig/RemoteConfig.csproj
+++ b/source/Firebase/RemoteConfig/RemoteConfig.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.RemoteConfig</RootNamespace>
     <AssemblyName>Firebase.RemoteConfig</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Storage/Storage.csproj
+++ b/source/Firebase/Storage/Storage.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Storage</RootNamespace>
     <AssemblyName>Firebase.Storage</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Google.GoogleAppMeasurement</RootNamespace>
     <AssemblyName>Google.GoogleAppMeasurement</AssemblyName>
-    <AssemblyVersion>12.6.0</AssemblyVersion>
-    <FileVersion>12.6.0</FileVersion>
+    <AssemblyVersion>12.7.0</AssemblyVersion>
+    <FileVersion>12.7.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.6.0</PackageVersion>
+    <PackageVersion>12.7.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_GoogleAppMeasurementAssemblyName>Google.GoogleAppMeasurement, Version=12.6.0, Culture=neutral, PublicKeyToken=null</_GoogleAppMeasurementAssemblyName>
+    <_GoogleAppMeasurementAssemblyName>Google.GoogleAppMeasurement, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_GoogleAppMeasurementAssemblyName>
   </PropertyGroup>
 </Project>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
@@ -20,8 +20,8 @@
     <RuntimeDriftCasePropsPath></RuntimeDriftCasePropsPath>
     <BindingSurfaceCoverageTarget></BindingSurfaceCoverageTarget>
     <BindingSurfaceCoveragePropsPath></BindingSurfaceCoveragePropsPath>
-    <FirebasePackageVersion>12.6.0</FirebasePackageVersion>
-    <GoogleAppMeasurementPackageVersion>12.6.0</GoogleAppMeasurementPackageVersion>
+    <FirebasePackageVersion>12.7.0</FirebasePackageVersion>
+    <GoogleAppMeasurementPackageVersion>12.7.0</GoogleAppMeasurementPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(RuntimeDriftCasePropsPath)" Condition="'$(RuntimeDriftCasePropsPath)' != '' and Exists('$(RuntimeDriftCasePropsPath)')" />

--- a/tests/E2E/Firebase.Foundation/README.md
+++ b/tests/E2E/Firebase.Foundation/README.md
@@ -95,7 +95,7 @@ tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug 
 
 ## Binding surface coverage mode
 
-The opt-in binding surface coverage lane accounts for the active Firebase `12.6.0` bindings tracked by the audit config. It generates a source-derived coverage inventory from [`binding-surface-coverage.json`](./binding-surface-coverage.json), restores the selected target package set from the local feed, and runs `ConfigureApp` plus the generated surface coverage case.
+The opt-in binding surface coverage lane accounts for the active Firebase `12.7.0` bindings tracked by the audit config. It generates a source-derived coverage inventory from [`binding-surface-coverage.json`](./binding-surface-coverage.json), restores the selected target package set from the local feed, and runs `ConfigureApp` plus the generated surface coverage case.
 
 This lane treats native Firebase/backend errors as acceptable when the binding surface is present and loadable. It fails binding-layer problems such as missing managed types, missing Objective-C classes/protocols/selectors, missing native symbols, `TypeLoadException`, `DllNotFoundException`, `EntryPointNotFoundException`, and `ObjCRuntime.ObjCException`.
 

--- a/tests/E2E/Firebase.Foundation/binding-surface-coverage.json
+++ b/tests/E2E/Firebase.Foundation/binding-surface-coverage.json
@@ -52,7 +52,7 @@
       "requiredExtraPackages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -165,7 +165,7 @@
       "requiredExtraPackages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -25,7 +25,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.AppCheck",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -36,11 +36,11 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.RemoteConfig",
-          "version": "12.6.0"
+          "version": "12.7.0"
         },
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -51,7 +51,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Database",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -62,7 +62,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Database",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -73,7 +73,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -84,7 +84,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -95,7 +95,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -106,7 +106,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -117,7 +117,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -128,7 +128,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -139,7 +139,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -150,7 +150,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -161,7 +161,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -172,7 +172,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -183,7 +183,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -194,7 +194,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFunctions",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -205,7 +205,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Crashlytics",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     },
@@ -216,7 +216,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Crashlytics",
-          "version": "12.6.0"
+          "version": "12.7.0"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Bump enabled Firebase binding package metadata from 12.6.0 to 12.7.0, including GoogleAppMeasurement.
- Update Firebase-family pod pins, project/package versions, targets metadata, Crashlytics script metadata, binding audit defaults, E2E validation metadata, and Firebase package docs.
- Keep binding definition files, generated output, GitHub automation, and cgmanifest out of scope.

## Validation

- `dotnet tool run dotnet-cake -- --target=firebase-release-check --firebase-version=12.7.0 --from-version=12.6.0`
- `dotnet test scripts/FirebaseBindingAudit.Tests/FirebaseBindingAudit.Tests.csproj`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.ABTesting,Firebase.Analytics,Firebase.AppCheck,Firebase.AppDistribution,Firebase.Auth,Firebase.CloudFirestore,Firebase.CloudFunctions,Firebase.CloudMessaging,Firebase.Core,Firebase.Crashlytics,Firebase.Database,Firebase.InAppMessaging,Firebase.Installations,Firebase.PerformanceMonitoring,Firebase.RemoteConfig,Firebase.Storage`
- `scripts/compare-firebase-bindings.sh --output-dir output/firebase-binding-audit-12.7`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Release`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --binding-surface-target all`

Full binding-surface E2E covered all 16 active Firebase targets with 1625/1625 surfaces exercised, 0 waived, and 0 failed.