### PR TITLE
[codex] Prepare Firebase 12.8 bindings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -142,7 +142,7 @@ If your project targets multiple platforms, keep these packages inside Apple-onl
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -166,7 +166,7 @@ Archiving can still be more reliable on macOS or from the command line.
 
 The lists below reflect what is currently published on [nuget.org](https://www.nuget.org/profiles/adamessenmacher) under the `adamessenmacher` owner profile. That is intentionally different from the repo state in [`components.cake`](components.cake): the repo can contain projects or version bumps that have not been published yet.
 
-Firebase `12.7.0` is the current published Firebase package line.
+Firebase `12.8.0` is the current published Firebase package line.
 
 ### Currently published on nuget.org
 
@@ -174,22 +174,22 @@ Firebase `12.7.0` is the current published Firebase package line.
 
 | Package | Version |
 | --- | --- |
-| `ABTesting` | `12.7.0` |
-| `Analytics` | `12.7.0` |
-| `AppCheck` | `12.7.0` |
-| `AppDistribution` | `12.7.0` |
-| `Auth` | `12.7.0` |
-| `CloudFirestore` | `12.7.0` |
-| `CloudFunctions` | `12.7.0` |
-| `CloudMessaging` | `12.7.0` |
-| `Core` | `12.7.0` |
-| `Crashlytics` | `12.7.0` |
-| `Database` | `12.7.0` |
-| `InAppMessaging` | `12.7.0` |
-| `Installations` | `12.7.0` |
-| `PerformanceMonitoring` | `12.7.0` |
-| `RemoteConfig` | `12.7.0` |
-| `Storage` | `12.7.0` |
+| `ABTesting` | `12.8.0` |
+| `Analytics` | `12.8.0` |
+| `AppCheck` | `12.8.0` |
+| `AppDistribution` | `12.8.0` |
+| `Auth` | `12.8.0` |
+| `CloudFirestore` | `12.8.0` |
+| `CloudFunctions` | `12.8.0` |
+| `CloudMessaging` | `12.8.0` |
+| `Core` | `12.8.0` |
+| `Crashlytics` | `12.8.0` |
+| `Database` | `12.8.0` |
+| `InAppMessaging` | `12.8.0` |
+| `Installations` | `12.8.0` |
+| `PerformanceMonitoring` | `12.8.0` |
+| `RemoteConfig` | `12.8.0` |
+| `Storage` | `12.8.0` |
 
 #### Google packages (`AdamE.Google.iOS.*`)
 
@@ -206,7 +206,7 @@ These packages are usually consumed transitively rather than referenced directly
 | Package | Version |
 | --- | --- |
 | `AppCheckCore` | `11.2.0` |
-| `GoogleAppMeasurement` | `12.7.0` |
+| `GoogleAppMeasurement` | `12.8.0` |
 | `GoogleDataTransport` | `10.1.0.5` |
 | `GoogleUtilities` | `8.1.0.3` |
 | `Nanopb` | `3.30910.0.5` |

--- a/components.cake
+++ b/components.cake
@@ -1,20 +1,20 @@
 // Firebase artifacts available to be built. These artifacts generate NuGets.
-Artifact FIREBASE_AB_TESTING_ARTIFACT              = new Artifact ("Firebase.ABTesting",              "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "ABTesting");
-Artifact FIREBASE_ANALYTICS_ARTIFACT               = new Artifact ("Firebase.Analytics",              "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Analytics");
-Artifact FIREBASE_AUTH_ARTIFACT                    = new Artifact ("Firebase.Auth",                   "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Auth");
-Artifact FIREBASE_CLOUD_FIRESTORE_ARTIFACT         = new Artifact ("Firebase.CloudFirestore",         "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFirestore");
-Artifact FIREBASE_CLOUD_FUNCTIONS_ARTIFACT         = new Artifact ("Firebase.CloudFunctions",         "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFunctions");
-Artifact FIREBASE_CLOUD_MESSAGING_ARTIFACT         = new Artifact ("Firebase.CloudMessaging",         "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudMessaging");
-Artifact FIREBASE_CORE_ARTIFACT                    = new Artifact ("Firebase.Core",                   "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Core");
-Artifact FIREBASE_CRASHLYTICS_ARTIFACT             = new Artifact ("Firebase.Crashlytics",            "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Crashlytics");
-Artifact FIREBASE_DATABASE_ARTIFACT                = new Artifact ("Firebase.Database",               "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Database");
-Artifact FIREBASE_IN_APP_MESSAGING_ARTIFACT        = new Artifact ("Firebase.InAppMessaging",         "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "InAppMessaging");
-Artifact FIREBASE_INSTALLATIONS_ARTIFACT           = new Artifact ("Firebase.Installations",          "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Installations");
-Artifact FIREBASE_PERFORMANCE_MONITORING_ARTIFACT  = new Artifact ("Firebase.PerformanceMonitoring",  "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "PerformanceMonitoring");
-Artifact FIREBASE_REMOTE_CONFIG_ARTIFACT           = new Artifact ("Firebase.RemoteConfig",           "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "RemoteConfig");
-Artifact FIREBASE_STORAGE_ARTIFACT                 = new Artifact ("Firebase.Storage",                "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "Storage");
-Artifact FIREBASE_APP_DISTRIBUTION_ARTIFACT        = new Artifact ("Firebase.AppDistribution",        "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppDistribution");
-Artifact FIREBASE_APP_CHECK_ARTIFACT               = new Artifact ("Firebase.AppCheck",               "12.7.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppCheck");
+Artifact FIREBASE_AB_TESTING_ARTIFACT              = new Artifact ("Firebase.ABTesting",              "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "ABTesting");
+Artifact FIREBASE_ANALYTICS_ARTIFACT               = new Artifact ("Firebase.Analytics",              "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "Analytics");
+Artifact FIREBASE_AUTH_ARTIFACT                    = new Artifact ("Firebase.Auth",                   "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "Auth");
+Artifact FIREBASE_CLOUD_FIRESTORE_ARTIFACT         = new Artifact ("Firebase.CloudFirestore",         "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFirestore");
+Artifact FIREBASE_CLOUD_FUNCTIONS_ARTIFACT         = new Artifact ("Firebase.CloudFunctions",         "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFunctions");
+Artifact FIREBASE_CLOUD_MESSAGING_ARTIFACT         = new Artifact ("Firebase.CloudMessaging",         "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudMessaging");
+Artifact FIREBASE_CORE_ARTIFACT                    = new Artifact ("Firebase.Core",                   "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "Core");
+Artifact FIREBASE_CRASHLYTICS_ARTIFACT             = new Artifact ("Firebase.Crashlytics",            "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "Crashlytics");
+Artifact FIREBASE_DATABASE_ARTIFACT                = new Artifact ("Firebase.Database",               "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "Database");
+Artifact FIREBASE_IN_APP_MESSAGING_ARTIFACT        = new Artifact ("Firebase.InAppMessaging",         "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "InAppMessaging");
+Artifact FIREBASE_INSTALLATIONS_ARTIFACT           = new Artifact ("Firebase.Installations",          "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "Installations");
+Artifact FIREBASE_PERFORMANCE_MONITORING_ARTIFACT  = new Artifact ("Firebase.PerformanceMonitoring",  "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "PerformanceMonitoring");
+Artifact FIREBASE_REMOTE_CONFIG_ARTIFACT           = new Artifact ("Firebase.RemoteConfig",           "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "RemoteConfig");
+Artifact FIREBASE_STORAGE_ARTIFACT                 = new Artifact ("Firebase.Storage",                "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "Storage");
+Artifact FIREBASE_APP_DISTRIBUTION_ARTIFACT        = new Artifact ("Firebase.AppDistribution",        "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppDistribution");
+Artifact FIREBASE_APP_CHECK_ARTIFACT               = new Artifact ("Firebase.AppCheck",               "12.8.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppCheck");
 
 // Google artifacts available to be built. These artifacts generate NuGets.
 Artifact GOOGLE_ANALYTICS_ARTIFACT                 = new Artifact ("Google.Analytics",                "3.20.0.2",  "15.0", ComponentGroup.Google, csprojName: "Analytics");
@@ -26,7 +26,7 @@ Artifact GOOGLE_APP_CHECK_CORE_ARTIFACT            = new Artifact ("Google.AppCh
 Artifact GOOGLE_SIGN_IN_ARTIFACT                   = new Artifact ("Google.SignIn",                   "9.0.0.0",   "15.0", ComponentGroup.Google, csprojName: "SignIn");
 Artifact GOOGLE_TAG_MANAGER_ARTIFACT               = new Artifact ("Google.TagManager",               "7.4.0.2",   "15.0", ComponentGroup.Google, csprojName: "TagManager");
 
-Artifact GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT    = new Artifact ("Google.AppMeasurement",           "12.7.0",      "15.0", ComponentGroup.Google, csprojName: "GoogleAppMeasurement");
+Artifact GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT    = new Artifact ("Google.AppMeasurement",           "12.8.0",      "15.0", ComponentGroup.Google, csprojName: "GoogleAppMeasurement");
 Artifact GOOGLE_PROMISES_OBJC_ARTIFACT             = new Artifact ("Google.PromisesObjC",             "2.4.0.5",     "15.0", ComponentGroup.Google, csprojName: "PromisesObjC");
 Artifact GOOGLE_GTM_SESSION_FETCHER_ARTIFACT       = new Artifact ("Google.GTMSessionFetcher",        "3.5.0.5",     "15.0", ComponentGroup.Google, csprojName: "GTMSessionFetcher");
 Artifact GOOGLE_NANOPB_ARTIFACT                    = new Artifact ("Google.Nanopb",                   "3.30910.0.5", "15.0", ComponentGroup.Google, csprojName: "Nanopb");
@@ -148,68 +148,68 @@ void SetArtifactsPodSpecs ()
 {
 	// Firebase components
 	FIREBASE_AB_TESTING_ARTIFACT.PodSpecs = new [] { 
-		PodSpec.Create ("FirebaseABTesting", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseABTesting", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_ANALYTICS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAnalytics", "12.7.0")
+		PodSpec.Create ("FirebaseAnalytics", "12.8.0")
 	};
 	FIREBASE_AUTH_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAuth",     "12.7.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseAuth",     "12.8.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("RecaptchaInterop", "101.0.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CLOUD_FIRESTORE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseFirestore",         "12.7.0",       frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseFirestoreInternal", "12.7.0",       frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseFirestore",         "12.8.0",       frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseFirestoreInternal", "12.8.0",       frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("BoringSSL-GRPC",            "0.0.37",       frameworkSource: FrameworkSource.Pods, frameworkName: "openssl_grpc"),
 		PodSpec.Create ("gRPC-Core",                 "1.69.0",       frameworkSource: FrameworkSource.Pods, frameworkName: "grpc"),
 		PodSpec.Create ("gRPC-C++",                  "1.69.0",       frameworkSource: FrameworkSource.Pods, frameworkName: "grpcpp"),
 		PodSpec.Create ("abseil",                    "1.20240722.0", frameworkSource: FrameworkSource.Pods, frameworkName: "absl", subSpecs: new [] { "algorithm", "base", "memory", "meta", "strings", "time", "types" }),
 	};
 	FIREBASE_CLOUD_FUNCTIONS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseFunctions", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseFunctions", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CLOUD_MESSAGING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseMessaging", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseMessaging", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CORE_ARTIFACT.PodSpecs = new [] {
-	    PodSpec.Create ("FirebaseAppCheckInterop",     "12.7.0", frameworkSource: FrameworkSource.Pods),
-	    PodSpec.Create ("FirebaseAuthInterop",         "12.7.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCore",                "12.7.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCoreExtension",       "12.7.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCoreInternal",        "12.7.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseMessagingInterop",    "12.7.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.7.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseSharedSwift",         "12.7.0", frameworkSource: FrameworkSource.Pods),
+	    PodSpec.Create ("FirebaseAppCheckInterop",     "12.8.0", frameworkSource: FrameworkSource.Pods),
+	    PodSpec.Create ("FirebaseAuthInterop",         "12.8.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCore",                "12.8.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCoreExtension",       "12.8.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCoreInternal",        "12.8.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseMessagingInterop",    "12.8.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.8.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseSharedSwift",         "12.8.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("PromisesSwift",               "2.4.0",  frameworkSource: FrameworkSource.Pods, frameworkName: "Promises", targetName: "PromisesSwift"),
 		PodSpec.Create ("leveldb-library",             "1.22.6", frameworkSource: FrameworkSource.Pods, frameworkName: "leveldb"),
 	};
 	FIREBASE_CRASHLYTICS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseCrashlytics", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseCrashlytics", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_DATABASE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseDatabase", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseDatabase", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_IN_APP_MESSAGING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("Firebase", "12.7.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
+		PodSpec.Create ("Firebase", "12.8.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
 	};
 	FIREBASE_INSTALLATIONS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseInstallations", "12.7.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseSessions",      "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseInstallations", "12.8.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseSessions",      "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_PERFORMANCE_MONITORING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebasePerformance", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebasePerformance", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_REMOTE_CONFIG_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseRemoteConfig", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseRemoteConfig", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_STORAGE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseStorage", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseStorage", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_APP_DISTRIBUTION_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("Firebase", "12.7.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseAppDistribution", targetName: "FirebaseAppDistribution", subSpecs: new [] { "AppDistribution" })
+		PodSpec.Create ("Firebase", "12.8.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseAppDistribution", targetName: "FirebaseAppDistribution", subSpecs: new [] { "AppDistribution" })
 	};
 	FIREBASE_APP_CHECK_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAppCheck", "12.7.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseAppCheck", "12.8.0", frameworkSource: FrameworkSource.Pods)
 	};
 
 	// Google components
@@ -240,7 +240,7 @@ void SetArtifactsPodSpecs ()
 		PodSpec.Create ("GoogleTagManager", "7.4.0")
 	};
     GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT.PodSpecs = new [] {
-        PodSpec.Create ("GoogleAppMeasurement", "12.7.0")
+        PodSpec.Create ("GoogleAppMeasurement", "12.8.0")
     };
 	GOOGLE_PROMISES_OBJC_ARTIFACT.PodSpecs = new [] {
 	    PodSpec.Create ("PromisesObjC", "2.4.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FBLPromises", targetName: "PromisesObjC"),

--- a/custom_externals_download.cake
+++ b/custom_externals_download.cake
@@ -20,8 +20,8 @@ class ExternalDownloadSource
 // FirebaseAnalytics: https://github.com/CocoaPods/Specs/tree/master/Specs/e/2/1/FirebaseAnalytics
 // GoogleAppMeasurement: https://github.com/CocoaPods/Specs/tree/master/Specs/e/3/b/GoogleAppMeasurement
 var ExternalDownloads = new Dictionary<string, ExternalDownloadSource> {
-	{ "FirebaseAnalytics", new ExternalDownloadSource ("FirebaseAnalytics", "12.5.0", "1d0a9f91196548b3") },
-	{ "GoogleAppMeasurement", new ExternalDownloadSource ("GoogleAppMeasurement", "12.5.0", "4a8fa8d922b0b454") },
+	{ "FirebaseAnalytics", new ExternalDownloadSource ("FirebaseAnalytics", "12.8.0", "3b57be475bd21097") },
+	{ "GoogleAppMeasurement", new ExternalDownloadSource ("GoogleAppMeasurement", "12.8.0", "48879432478c47b8") },
 };
 
 FilePath GetArchivePath (ExternalDownloadSource source, DirectoryPath externalsPath) =>

--- a/docs/Firebase/NuGet/ABTesting.md
+++ b/docs/Firebase/NuGet/ABTesting.md
@@ -46,7 +46,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.ABTesting" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.ABTesting" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -121,9 +121,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Analytics.md
+++ b/docs/Firebase/NuGet/Analytics.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Analytics" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -104,9 +104,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/AppCheck.md
+++ b/docs/Firebase/NuGet/AppCheck.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.AppCheck" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -106,9 +106,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/AppDistribution.md
+++ b/docs/Firebase/NuGet/AppDistribution.md
@@ -46,7 +46,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.AppDistribution" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.AppDistribution" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -88,7 +88,7 @@ if (!appDistribution.IsTesterSignedIn)
 - `AdamE.Firebase.iOS.Core` - Firebase app initialization.
 - `AdamE.Firebase.iOS.Installations` - package metadata references Firebase Installations for underlying Firebase identity support.
 
-This package is part of the Firebase `12.7.0` package line. Firebase's `12.7.0` aggregate CocoaPods spec exposes App Distribution through `Firebase/AppDistribution`, which resolves the native `FirebaseAppDistribution` pod at `12.7.0-beta`.
+This package is part of the Firebase `12.8.0` package line. Firebase's `12.8.0` aggregate CocoaPods spec exposes App Distribution through `Firebase/AppDistribution`, which resolves the native `FirebaseAppDistribution` pod at `12.8.0-beta`.
 
 ## Firebase app configuration
 
@@ -111,9 +111,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Auth.md
+++ b/docs/Firebase/NuGet/Auth.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -114,9 +114,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudFirestore.md
+++ b/docs/Firebase/NuGet/CloudFirestore.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -116,9 +116,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudFunctions.md
+++ b/docs/Firebase/NuGet/CloudFunctions.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFunctions" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -110,9 +110,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/CloudMessaging.md
+++ b/docs/Firebase/NuGet/CloudMessaging.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudMessaging" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -112,9 +112,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Core.md
+++ b/docs/Firebase/NuGet/Core.md
@@ -46,7 +46,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -104,9 +104,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Crashlytics.md
+++ b/docs/Firebase/NuGet/Crashlytics.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Crashlytics" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -109,9 +109,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Database.md
+++ b/docs/Firebase/NuGet/Database.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Database" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Database" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -107,9 +107,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/InAppMessaging.md
+++ b/docs/Firebase/NuGet/InAppMessaging.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.InAppMessaging" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.InAppMessaging" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -79,7 +79,7 @@ inAppMessaging.TriggerEvent("purchase_complete");
 - `AdamE.Firebase.iOS.ABTesting` - package metadata references Firebase A/B Testing for campaign experiment handling.
 - `AdamE.Firebase.iOS.Analytics` - commonly used with In-App Messaging campaign triggers and measurement.
 
-This package is part of the Firebase `12.7.0` package line in this repository. Firebase's aggregate `Firebase/InAppMessaging` `12.7.0` CocoaPods subspec resolves the native `FirebaseInAppMessaging` `12.7.0-beta` pod.
+This package is part of the Firebase `12.8.0` package line in this repository. Firebase's aggregate `Firebase/InAppMessaging` `12.8.0` CocoaPods subspec resolves the native `FirebaseInAppMessaging` `12.8.0-beta` pod.
 
 ## Firebase app configuration
 
@@ -102,9 +102,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Installations.md
+++ b/docs/Firebase/NuGet/Installations.md
@@ -46,7 +46,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Installations" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Installations" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -112,9 +112,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/PerformanceMonitoring.md
+++ b/docs/Firebase/NuGet/PerformanceMonitoring.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.PerformanceMonitoring" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.PerformanceMonitoring" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -109,9 +109,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/RemoteConfig.md
+++ b/docs/Firebase/NuGet/RemoteConfig.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.RemoteConfig" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -114,9 +114,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/docs/Firebase/NuGet/Storage.md
+++ b/docs/Firebase/NuGet/Storage.md
@@ -47,7 +47,7 @@ When multi-targeting, condition the package reference so it only restores for Ap
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-  <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Storage" Version="12.8.0" />
 </ItemGroup>
 ```
 
@@ -115,9 +115,9 @@ Example:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.7.0" />
-  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.7.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Auth" Version="12.8.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.CloudFirestore" Version="12.8.0" />
 </ItemGroup>
 ```
 

--- a/scripts/FirebaseBindingAudit/BindingSurfaceCoverage.cs
+++ b/scripts/FirebaseBindingAudit/BindingSurfaceCoverage.cs
@@ -10,7 +10,7 @@ namespace FirebaseBindingAudit;
 
 internal static class FirebasePackageVersions
 {
-    public const string DefaultFirebasePackageVersion = "12.7.0";
+    public const string DefaultFirebasePackageVersion = "12.8.0";
 }
 
 internal sealed class BindingSurfaceCoverageManifest

--- a/scripts/firebase-binding-audit-suppressions.json
+++ b/scripts/firebase-binding-audit-suppressions.json
@@ -1606,6 +1606,391 @@
       ]
     },
     {
+      "id": "cloudfirestore-exprbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.ExprBridge",
+      "comparisonTypeKey": "FIRExprBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L32-L35"
+      ]
+    },
+    {
+      "id": "cloudfirestore-fieldbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.FieldBridge",
+      "comparisonTypeKey": "FIRFieldBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L37-L43"
+      ]
+    },
+    {
+      "id": "cloudfirestore-constantbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.ConstantBridge",
+      "comparisonTypeKey": "FIRConstantBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L45-L49"
+      ]
+    },
+    {
+      "id": "cloudfirestore-functionexprbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.FunctionExprBridge",
+      "comparisonTypeKey": "FIRFunctionExprBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L51-L55"
+      ]
+    },
+    {
+      "id": "cloudfirestore-aggregatefunctionbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.AggregateFunctionBridge",
+      "comparisonTypeKey": "FIRAggregateFunctionBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L57-L61"
+      ]
+    },
+    {
+      "id": "cloudfirestore-orderingbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.OrderingBridge",
+      "comparisonTypeKey": "FIROrderingBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L63-L67"
+      ]
+    },
+    {
+      "id": "cloudfirestore-stagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.StageBridge",
+      "comparisonTypeKey": "FIRStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L69-L73"
+      ]
+    },
+    {
+      "id": "cloudfirestore-collectionsourcestagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.CollectionSourceStageBridge",
+      "comparisonTypeKey": "FIRCollectionSourceStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L75-L80"
+      ]
+    },
+    {
+      "id": "cloudfirestore-databasesourcestagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.DatabaseSourceStageBridge",
+      "comparisonTypeKey": "FIRDatabaseSourceStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L82-L87"
+      ]
+    },
+    {
+      "id": "cloudfirestore-collectiongroupsourcestagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.CollectionGroupSourceStageBridge",
+      "comparisonTypeKey": "FIRCollectionGroupSourceStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L89-L94"
+      ]
+    },
+    {
+      "id": "cloudfirestore-documentssourcestagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.DocumentsSourceStageBridge",
+      "comparisonTypeKey": "FIRDocumentsSourceStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L96-L101"
+      ]
+    },
+    {
+      "id": "cloudfirestore-wherestagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.WhereStageBridge",
+      "comparisonTypeKey": "FIRWhereStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L103-L108"
+      ]
+    },
+    {
+      "id": "cloudfirestore-limitstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.LimitStageBridge",
+      "comparisonTypeKey": "FIRLimitStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L110-L115"
+      ]
+    },
+    {
+      "id": "cloudfirestore-offsetstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.OffsetStageBridge",
+      "comparisonTypeKey": "FIROffsetStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L117-L122"
+      ]
+    },
+    {
+      "id": "cloudfirestore-addfieldsstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.AddFieldsStageBridge",
+      "comparisonTypeKey": "FIRAddFieldsStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L124-L128"
+      ]
+    },
+    {
+      "id": "cloudfirestore-removefieldsstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.RemoveFieldsStageBridge",
+      "comparisonTypeKey": "FIRRemoveFieldsStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L130-L134"
+      ]
+    },
+    {
+      "id": "cloudfirestore-selectstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.SelectStageBridge",
+      "comparisonTypeKey": "FIRSelectStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L136-L140"
+      ]
+    },
+    {
+      "id": "cloudfirestore-distinctstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.DistinctStageBridge",
+      "comparisonTypeKey": "FIRDistinctStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L142-L146"
+      ]
+    },
+    {
+      "id": "cloudfirestore-aggregatestagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.AggregateStageBridge",
+      "comparisonTypeKey": "FIRAggregateStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L148-L153"
+      ]
+    },
+    {
+      "id": "cloudfirestore-findneareststagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.FindNearestStageBridge",
+      "comparisonTypeKey": "FIRFindNearestStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L155-L163"
+      ]
+    },
+    {
+      "id": "cloudfirestore-sortstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.SortStageBridge",
+      "comparisonTypeKey": "FIRSorStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L165-L169"
+      ]
+    },
+    {
+      "id": "cloudfirestore-replacewithstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.ReplaceWithStageBridge",
+      "comparisonTypeKey": "FIRReplaceWithStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L171-L175"
+      ]
+    },
+    {
+      "id": "cloudfirestore-samplestagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.SampleStageBridge",
+      "comparisonTypeKey": "FIRSampleStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L177-L182"
+      ]
+    },
+    {
+      "id": "cloudfirestore-unionstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.UnionStageBridge",
+      "comparisonTypeKey": "FIRUnionStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L184-L188"
+      ]
+    },
+    {
+      "id": "cloudfirestore-unneststagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.UnnestStageBridge",
+      "comparisonTypeKey": "FIRUnnestStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L190-L196"
+      ]
+    },
+    {
+      "id": "cloudfirestore-rawstagebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.RawStageBridge",
+      "comparisonTypeKey": "FIRRawStageBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L198-L204"
+      ]
+    },
+    {
+      "id": "cloudfirestore-pipelineresultbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.PipelineResultBridge",
+      "comparisonTypeKey": "__FIRPipelineResultBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L206-L228"
+      ]
+    },
+    {
+      "id": "cloudfirestore-pipelineresultchangebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.PipelineResultChangeBridge",
+      "comparisonTypeKey": "__FIRPipelineResultChangeBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L230-L244"
+      ]
+    },
+    {
+      "id": "cloudfirestore-pipelinesnapshotbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.PipelineSnapshotBridge",
+      "comparisonTypeKey": "__FIRPipelineSnapshotBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L246-L254"
+      ]
+    },
+    {
+      "id": "cloudfirestore-pipelinebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.PipelineBridge",
+      "comparisonTypeKey": "FIRPipelineBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L256-L267"
+      ]
+    },
+    {
+      "id": "cloudfirestore-realtimepipelinesnapshotbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.RealtimePipelineSnapshotBridge",
+      "comparisonTypeKey": "__FIRRealtimePipelineSnapshotBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L269-L279"
+      ]
+    },
+    {
+      "id": "cloudfirestore-pipelinelistenoptionsbridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.PipelineListenOptionsBridge",
+      "comparisonTypeKey": "__FIRPipelineListenOptionsBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L281-L297"
+      ]
+    },
+    {
+      "id": "cloudfirestore-realtimepipelinebridge-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.RealtimePipelineBridge",
+      "comparisonTypeKey": "FIRRealtimePipelineBridge",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline binding. The declaration is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L299-L313"
+      ]
+    },
+    {
+      "id": "cloudfirestore-pipelinesnapshothandler-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.PipelineSnapshotHandler",
+      "comparisonTypeKey": "PipelineSnapshotHandler",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline delegate. The matching pipeline completion block is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L263-L264"
+      ]
+    },
+    {
+      "id": "cloudfirestore-realtimepipelinesnapshothandler-sharpie-wrapper-omission",
+      "target": "CloudFirestore",
+      "category": "stale-baseline-binding",
+      "typeName": "Firebase.CloudFirestore.RealtimePipelineSnapshotHandler",
+      "comparisonTypeKey": "RealtimePipelineSnapshotHandler",
+      "reason": "Sharpie currently fails to build the FirebaseFirestore wrapper module during this audit pass, so fresh output omits this baseline delegate. The matching realtime pipeline listener block is present in FIRPipelineBridge.h in the observable FirebaseFirestoreInternal headers imported by the public FirebaseFirestore framework.",
+      "evidence": [
+        "externals/FirebaseFirestoreInternal.xcframework/ios-arm64/FirebaseFirestoreInternal.framework/Headers/FIRPipelineBridge.h#L306-L310"
+      ]
+    },
+    {
       "id": "cloudfirestore-collectionreference-sharpie-wrapper-omission",
       "target": "CloudFirestore",
       "category": "stale-baseline-binding",

--- a/source/Firebase/ABTesting/ABTesting.csproj
+++ b/source/Firebase/ABTesting/ABTesting.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.ABTesting</RootNamespace>
     <AssemblyName>Firebase.ABTesting</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Analytics/Analytics.csproj
+++ b/source/Firebase/Analytics/Analytics.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Analytics</RootNamespace>
     <AssemblyName>Firebase.Analytics</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProcessEnums>true</ProcessEnums>
@@ -28,7 +28,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />
@@ -57,7 +57,7 @@
     <ObjcBindingApiDefinition Include="Enums.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AdamE.Google.iOS.GoogleAppMeasurement" Version="12.7.0" />
+    <PackageReference Include="AdamE.Google.iOS.GoogleAppMeasurement" Version="12.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" PrivateAssets="None" />

--- a/source/Firebase/Analytics/Analytics.targets
+++ b/source/Firebase/Analytics/Analytics.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
+    <_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=12.8.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/AppCheck/AppCheck.csproj
+++ b/source/Firebase/AppCheck/AppCheck.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.AppCheck</RootNamespace>
     <AssemblyName>Firebase.AppCheck</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/AppCheck/AppCheck.targets
+++ b/source/Firebase/AppCheck/AppCheck.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseAppCheckAssemblyName>Firebase.AppCheck, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_FirebaseAppCheckAssemblyName>
+    <_FirebaseAppCheckAssemblyName>Firebase.AppCheck, Version=12.8.0, Culture=neutral, PublicKeyToken=null</_FirebaseAppCheckAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/AppDistribution/AppDistribution.csproj
+++ b/source/Firebase/AppDistribution/AppDistribution.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.AppDistribution</RootNamespace>
     <AssemblyName>Firebase.AppDistribution</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Auth/Auth.csproj
+++ b/source/Firebase/Auth/Auth.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Auth</RootNamespace>
     <AssemblyName>Firebase.Auth</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudFirestore/ApiDefinition.cs
+++ b/source/Firebase/CloudFirestore/ApiDefinition.cs
@@ -363,6 +363,436 @@ namespace Firebase.CloudFirestore
 		NativeHandle Constructor (NSNumber [] array);
 	}
 
+	// typedef void (^FIRPipelineSnapshotBlock)(__FIRPipelineSnapshotBridge * _Nullable result, NSError * _Nullable error);
+	delegate void PipelineSnapshotHandler ([NullAllowed] PipelineSnapshotBridge result, [NullAllowed] NSError error);
+
+	// typedef void (^FIRRealtimePipelineSnapshotBlock)(__FIRRealtimePipelineSnapshotBridge * _Nullable snapshot, NSError * _Nullable error);
+	delegate void RealtimePipelineSnapshotHandler ([NullAllowed] RealtimePipelineSnapshotBridge snapshot, [NullAllowed] NSError error);
+
+	// @interface FIRExprBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIRExprBridge")]
+	interface ExprBridge
+	{
+	}
+
+	// @interface FIRFieldBridge : FIRExprBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (ExprBridge), Name = "FIRFieldBridge")]
+	interface FieldBridge
+	{
+		// - (id)initWithName:(NSString *)name;
+		[Export ("initWithName:")]
+		NativeHandle Constructor (string name);
+
+		// - (id)initWithPath:(FIRFieldPath *)path;
+		[Export ("initWithPath:")]
+		NativeHandle Constructor (FieldPath path);
+
+		// - (NSString *)field_name;
+		[Export ("field_name")]
+		string FieldName { get; }
+	}
+
+	// @interface FIRConstantBridge : FIRExprBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (ExprBridge), Name = "FIRConstantBridge")]
+	interface ConstantBridge
+	{
+		// - (id)init:(id)input;
+		[Export ("init:")]
+		NativeHandle Constructor (NSObject input);
+	}
+
+	// @interface FIRFunctionExprBridge : FIRExprBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (ExprBridge), Name = "FIRFunctionExprBridge")]
+	interface FunctionExprBridge
+	{
+		// - (id)initWithName:(NSString *)name Args:(NSArray<FIRExprBridge *> *)args;
+		[Export ("initWithName:Args:")]
+		NativeHandle Constructor (string name, ExprBridge [] args);
+	}
+
+	// @interface FIRAggregateFunctionBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIRAggregateFunctionBridge")]
+	interface AggregateFunctionBridge
+	{
+		// - (id)initWithName:(NSString *)name Args:(NSArray<FIRExprBridge *> *)args;
+		[Export ("initWithName:Args:")]
+		NativeHandle Constructor (string name, ExprBridge [] args);
+	}
+
+	// @interface FIROrderingBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIROrderingBridge")]
+	interface OrderingBridge
+	{
+		// - (id)initWithExpr:(FIRExprBridge *)expr Direction:(NSString *)direction;
+		[Export ("initWithExpr:Direction:")]
+		NativeHandle Constructor (ExprBridge expr, string direction);
+	}
+
+	// @interface FIRStageBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIRStageBridge")]
+	interface StageBridge
+	{
+		// @property(nonatomic, readonly) NSString *name;
+		[Export ("name")]
+		string Name { get; }
+	}
+
+	// @interface FIRCollectionSourceStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRCollectionSourceStageBridge")]
+	interface CollectionSourceStageBridge
+	{
+		// - (id)initWithRef:(FIRCollectionReference *)ref firestore:(FIRFirestore *)db;
+		[Export ("initWithRef:firestore:")]
+		NativeHandle Constructor (CollectionReference reference, Firestore db);
+	}
+
+	// @interface FIRDatabaseSourceStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRDatabaseSourceStageBridge")]
+	interface DatabaseSourceStageBridge
+	{
+		// - (id)init;
+		[Export ("init")]
+		NativeHandle Constructor ();
+	}
+
+	// @interface FIRCollectionGroupSourceStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRCollectionGroupSourceStageBridge")]
+	interface CollectionGroupSourceStageBridge
+	{
+		// - (id)initWithCollectionId:(NSString *)id;
+		[Export ("initWithCollectionId:")]
+		NativeHandle Constructor (string collectionId);
+	}
+
+	// @interface FIRDocumentsSourceStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRDocumentsSourceStageBridge")]
+	interface DocumentsSourceStageBridge
+	{
+		// - (id)initWithDocuments:(NSArray<FIRDocumentReference *> *)documents firestore:(FIRFirestore *)db;
+		[Export ("initWithDocuments:firestore:")]
+		NativeHandle Constructor (DocumentReference [] documents, Firestore db);
+	}
+
+	// @interface FIRWhereStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRWhereStageBridge")]
+	interface WhereStageBridge
+	{
+		// - (id)initWithExpr:(FIRExprBridge *)expr;
+		[Export ("initWithExpr:")]
+		NativeHandle Constructor (ExprBridge expr);
+	}
+
+	// @interface FIRLimitStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRLimitStageBridge")]
+	interface LimitStageBridge
+	{
+		// - (id)initWithLimit:(NSInteger)value;
+		[Export ("initWithLimit:")]
+		NativeHandle Constructor (nint value);
+	}
+
+	// @interface FIROffsetStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIROffsetStageBridge")]
+	interface OffsetStageBridge
+	{
+		// - (id)initWithOffset:(NSInteger)value;
+		[Export ("initWithOffset:")]
+		NativeHandle Constructor (nint value);
+	}
+
+	// @interface FIRAddFieldsStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRAddFieldsStageBridge")]
+	interface AddFieldsStageBridge
+	{
+		// - (id)initWithFields:(NSDictionary<NSString *, FIRExprBridge *> *)fields;
+		[Export ("initWithFields:")]
+		NativeHandle Constructor (NSDictionary<NSString, NSObject> fields);
+	}
+
+	// @interface FIRRemoveFieldsStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRRemoveFieldsStageBridge")]
+	interface RemoveFieldsStageBridge
+	{
+		// - (id)initWithFields:(NSArray<NSString *> *)fields;
+		[Export ("initWithFields:")]
+		NativeHandle Constructor (string [] fields);
+	}
+
+	// @interface FIRSelectStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRSelectStageBridge")]
+	interface SelectStageBridge
+	{
+		// - (id)initWithSelections:(NSDictionary<NSString *, FIRExprBridge *> *)selections;
+		[Export ("initWithSelections:")]
+		NativeHandle Constructor (NSDictionary<NSString, NSObject> selections);
+	}
+
+	// @interface FIRDistinctStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRDistinctStageBridge")]
+	interface DistinctStageBridge
+	{
+		// - (id)initWithGroups:(NSDictionary<NSString *, FIRExprBridge *> *)groups;
+		[Export ("initWithGroups:")]
+		NativeHandle Constructor (NSDictionary<NSString, NSObject> groups);
+	}
+
+	// @interface FIRAggregateStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRAggregateStageBridge")]
+	interface AggregateStageBridge
+	{
+		// - (id)initWithAccumulators:(NSDictionary<NSString *, FIRAggregateFunctionBridge *> *)accumulators groups:(NSDictionary<NSString *, FIRExprBridge *> *)groups;
+		[Export ("initWithAccumulators:groups:")]
+		NativeHandle Constructor (NSDictionary<NSString, NSObject> accumulators, NSDictionary<NSString, NSObject> groups);
+	}
+
+	// @interface FIRFindNearestStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRFindNearestStageBridge")]
+	interface FindNearestStageBridge
+	{
+		// - (id)initWithField:(FIRFieldBridge *)field vectorValue:(FIRVectorValue *)vectorValue distanceMeasure:(NSString *)distanceMeasure limit:(NSNumber * _Nullable)limit distanceField:(FIRExprBridge * _Nullable)distanceField;
+		[Export ("initWithField:vectorValue:distanceMeasure:limit:distanceField:")]
+		NativeHandle Constructor (FieldBridge field, VectorValue vectorValue, string distanceMeasure, [NullAllowed] NSNumber limit, [NullAllowed] ExprBridge distanceField);
+	}
+
+	// @interface FIRSorStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRSorStageBridge")]
+	interface SortStageBridge
+	{
+		// - (id)initWithOrderings:(NSArray<id> *)orderings;
+		[Export ("initWithOrderings:")]
+		NativeHandle Constructor (NSObject [] orderings);
+	}
+
+	// @interface FIRReplaceWithStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRReplaceWithStageBridge")]
+	interface ReplaceWithStageBridge
+	{
+		// - (id)initWithExpr:(FIRExprBridge *)expr;
+		[Export ("initWithExpr:")]
+		NativeHandle Constructor (ExprBridge expr);
+	}
+
+	// @interface FIRSampleStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRSampleStageBridge")]
+	interface SampleStageBridge
+	{
+		// - (id)initWithCount:(int64_t)count;
+		[Export ("initWithCount:")]
+		NativeHandle Constructor (long count);
+
+		// - (id)initWithPercentage:(double)percentage;
+		[Export ("initWithPercentage:")]
+		NativeHandle Constructor (double percentage);
+	}
+
+	// @interface FIRUnionStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRUnionStageBridge")]
+	interface UnionStageBridge
+	{
+		// - (id)initWithOther:(FIRPipelineBridge *)other;
+		[Export ("initWithOther:")]
+		NativeHandle Constructor (PipelineBridge other);
+	}
+
+	// @interface FIRUnnestStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRUnnestStageBridge")]
+	interface UnnestStageBridge
+	{
+		// - (id)initWithField:(FIRExprBridge *)field alias:(FIRExprBridge *)alias indexField:(FIRExprBridge * _Nullable)index_field;
+		[Export ("initWithField:alias:indexField:")]
+		NativeHandle Constructor (ExprBridge field, ExprBridge alias, [NullAllowed] ExprBridge indexField);
+	}
+
+	// @interface FIRRawStageBridge : FIRStageBridge
+	[DisableDefaultCtor]
+	[BaseType (typeof (StageBridge), Name = "FIRRawStageBridge")]
+	interface RawStageBridge
+	{
+		// - (id)initWithName:(NSString *)name params:(NSArray<id> *)params options:(NSDictionary<NSString *, FIRExprBridge *> * _Nullable)options;
+		[Export ("initWithName:params:options:")]
+		NativeHandle Constructor (string name, NSObject [] @params, [NullAllowed] NSDictionary<NSString, NSObject> options);
+	}
+
+	// @interface __FIRPipelineResultBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "__FIRPipelineResultBridge")]
+	interface PipelineResultBridge
+	{
+		// @property(nonatomic, strong, readonly, nullable) FIRDocumentReference *reference;
+		[NullAllowed]
+		[Export ("reference", ArgumentSemantic.Strong)]
+		DocumentReference Reference { get; }
+
+		// @property(nonatomic, copy, readonly, nullable) NSString *documentID;
+		[NullAllowed]
+		[Export ("documentID")]
+		string Id { get; }
+
+		// @property(nonatomic, strong, readonly, nullable) FIRTimestamp *create_time;
+		[NullAllowed]
+		[Export ("create_time", ArgumentSemantic.Strong)]
+		Firebase.Core.Timestamp CreateTime { get; }
+
+		// @property(nonatomic, strong, readonly, nullable) FIRTimestamp *update_time;
+		[NullAllowed]
+		[Export ("update_time", ArgumentSemantic.Strong)]
+		Firebase.Core.Timestamp UpdateTime { get; }
+
+		// - (NSDictionary<NSString *, id> *)data;
+		[Export ("data")]
+		NSDictionary<NSString, NSObject> Data { get; }
+
+		// - (NSDictionary<NSString *, id> *)dataWithServerTimestampBehavior:(FIRServerTimestampBehavior)serverTimestampBehavior;
+		[Export ("dataWithServerTimestampBehavior:")]
+		NSDictionary<NSString, NSObject> GetData (ServerTimestampBehavior serverTimestampBehavior);
+
+		// - (nullable id)get:(id)field;
+		[return: NullAllowed]
+		[Export ("get:")]
+		NSObject GetValue (NSObject field);
+
+		// - (nullable id)get:(id)field serverTimestampBehavior:(FIRServerTimestampBehavior)serverTimestampBehavior;
+		[return: NullAllowed]
+		[Export ("get:serverTimestampBehavior:")]
+		NSObject GetValue (NSObject field, ServerTimestampBehavior serverTimestampBehavior);
+	}
+
+	// @interface __FIRPipelineResultChangeBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "__FIRPipelineResultChangeBridge")]
+	interface PipelineResultChangeBridge
+	{
+		// @property(nonatomic, readonly) FIRDocumentChangeType type;
+		[Export ("type")]
+		DocumentChangeType Type { get; }
+
+		// @property(nonatomic, strong, readonly) __FIRPipelineResultBridge *result;
+		[Export ("result", ArgumentSemantic.Strong)]
+		PipelineResultBridge Result { get; }
+
+		// @property(nonatomic, readonly) NSUInteger oldIndex;
+		[Export ("oldIndex")]
+		nuint OldIndex { get; }
+
+		// @property(nonatomic, readonly) NSUInteger newIndex;
+		[Export ("newIndex")]
+		nuint NewIndex { get; }
+	}
+
+	// @interface __FIRPipelineSnapshotBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "__FIRPipelineSnapshotBridge")]
+	interface PipelineSnapshotBridge
+	{
+		// @property(nonatomic, strong, readonly) NSArray<__FIRPipelineResultBridge *> *results;
+		[Export ("results", ArgumentSemantic.Strong)]
+		PipelineResultBridge [] Results { get; }
+
+		// @property(nonatomic, strong, readonly) FIRTimestamp *execution_time;
+		[Export ("execution_time", ArgumentSemantic.Strong)]
+		Firebase.Core.Timestamp ExecutionTime { get; }
+	}
+
+	// @interface FIRPipelineBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIRPipelineBridge")]
+	interface PipelineBridge
+	{
+		// - (id)initWithStages:(NSArray<FIRStageBridge *> *)stages db:(FIRFirestore *)db;
+		[Export ("initWithStages:db:")]
+		NativeHandle Constructor (StageBridge [] stages, Firestore db);
+
+		// - (void)executeWithCompletion:(void (^)(__FIRPipelineSnapshotBridge * _Nullable result, NSError * _Nullable error))completion;
+		[Async]
+		[Export ("executeWithCompletion:")]
+		void Execute (PipelineSnapshotHandler completion);
+
+		// + (NSArray<FIRStageBridge *> *)createStageBridgesFromQuery:(FIRQuery *)query;
+		[Static]
+		[Export ("createStageBridgesFromQuery:")]
+		StageBridge [] CreateStageBridges (Query query);
+	}
+
+	// @interface __FIRRealtimePipelineSnapshotBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "__FIRRealtimePipelineSnapshotBridge")]
+	interface RealtimePipelineSnapshotBridge
+	{
+		// @property(nonatomic, strong, readonly) NSArray<__FIRPipelineResultBridge *> *results;
+		[Export ("results", ArgumentSemantic.Strong)]
+		PipelineResultBridge [] Results { get; }
+
+		// @property(nonatomic, strong, readonly) NSArray<__FIRPipelineResultChangeBridge *> *changes;
+		[Export ("changes", ArgumentSemantic.Strong)]
+		PipelineResultChangeBridge [] Changes { get; }
+
+		// @property(nonatomic, strong, readonly) FIRSnapshotMetadata *metadata;
+		[Export ("metadata", ArgumentSemantic.Strong)]
+		SnapshotMetadata Metadata { get; }
+	}
+
+	// @interface __FIRPipelineListenOptionsBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "__FIRPipelineListenOptionsBridge")]
+	interface PipelineListenOptionsBridge
+	{
+		// @property(nonatomic, readonly) NSString *serverTimestampBehavior;
+		[Export ("serverTimestampBehavior")]
+		string ServerTimestampBehavior { get; }
+
+		// @property(nonatomic, readonly) BOOL includeMetadata;
+		[Export ("includeMetadata")]
+		bool IncludeMetadata { get; }
+
+		// @property(nonatomic, readonly) FIRListenSource source;
+		[Export ("source")]
+		ListenSource Source { get; }
+
+		// - (instancetype)initWithServerTimestampBehavior:(NSString *)serverTimestampBehavior includeMetadata:(BOOL)includeMetadata source:(FIRListenSource)source NS_DESIGNATED_INITIALIZER;
+		[DesignatedInitializer]
+		[Export ("initWithServerTimestampBehavior:includeMetadata:source:")]
+		NativeHandle Constructor (string serverTimestampBehavior, bool includeMetadata, ListenSource source);
+	}
+
+	// @interface FIRRealtimePipelineBridge : NSObject
+	[DisableDefaultCtor]
+	[BaseType (typeof (NSObject), Name = "FIRRealtimePipelineBridge")]
+	interface RealtimePipelineBridge
+	{
+		// - (id)initWithStages:(NSArray<FIRStageBridge *> *)stages db:(FIRFirestore *)db;
+		[Export ("initWithStages:db:")]
+		NativeHandle Constructor (StageBridge [] stages, Firestore db);
+
+		// - (id<FIRListenerRegistration>)addSnapshotListenerWithOptions:(__FIRPipelineListenOptionsBridge *)options listener:(void (^)(__FIRRealtimePipelineSnapshotBridge * _Nullable snapshot, NSError * _Nullable error))listener;
+		[Export ("addSnapshotListenerWithOptions:listener:")]
+		IListenerRegistration AddSnapshotListener (PipelineListenOptionsBridge options, RealtimePipelineSnapshotHandler listener);
+	}
+
 	// @interface FIRAggregateField : NSObject
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRAggregateField")]

--- a/source/Firebase/CloudFirestore/CloudFirestore.csproj
+++ b/source/Firebase/CloudFirestore/CloudFirestore.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudFirestore</RootNamespace>
     <AssemblyName>Firebase.CloudFirestore</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudFunctions/CloudFunctions.csproj
+++ b/source/Firebase/CloudFunctions/CloudFunctions.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudFunctions</RootNamespace>
     <AssemblyName>Firebase.CloudFunctions</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudMessaging/CloudMessaging.csproj
+++ b/source/Firebase/CloudMessaging/CloudMessaging.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudMessaging</RootNamespace>
     <AssemblyName>Firebase.CloudMessaging</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Core</RootNamespace>
     <AssemblyName>Firebase.Core</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Core/Core.targets
+++ b/source/Firebase/Core/Core.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseCoreAssemblyName>Firebase.Core, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_FirebaseCoreAssemblyName>
+    <_FirebaseCoreAssemblyName>Firebase.Core, Version=12.8.0, Culture=neutral, PublicKeyToken=null</_FirebaseCoreAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/Crashlytics/Crashlytics.csproj
+++ b/source/Firebase/Crashlytics/Crashlytics.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Crashlytics</RootNamespace>
     <AssemblyName>Firebase.Crashlytics</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Crashlytics/Crashlytics.targets
+++ b/source/Firebase/Crashlytics/Crashlytics.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <_FirebaseCrashlyticsAssemblyName>Firebase.Crashlytics, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_FirebaseCrashlyticsAssemblyName>
-    <_FirebaseCrashlyticsItemsFolder>FCrshlytcs-12.7.0</_FirebaseCrashlyticsItemsFolder>
+    <_FirebaseCrashlyticsAssemblyName>Firebase.Crashlytics, Version=12.8.0, Culture=neutral, PublicKeyToken=null</_FirebaseCrashlyticsAssemblyName>
+    <_FirebaseCrashlyticsItemsFolder>FCrshlytcs-12.8.0</_FirebaseCrashlyticsItemsFolder>
     <_FirebaseCrashlyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseCrashlyticsItemsFolder)\</_FirebaseCrashlyticsSDKBaseFolder>
     <!-- Requires a file extension, otherwise XDB will complain  -->
     <_FirebaseScriptName>upload-symbols.sh</_FirebaseScriptName>
@@ -22,7 +22,7 @@
   <ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
     <XamarinBuildDownload Include="$(_FirebaseCrashlyticsItemsFolder)">
       <!-- To upgrade, change commit id from the appropriate tag: https://github.com/firebase/firebase-ios-sdk/tags-->
-      <Url>https://raw.githubusercontent.com/firebase/firebase-ios-sdk/45210bd1ea695779e6de016ab00fea8c0b7eb2ef/Crashlytics/upload-symbols</Url>
+      <Url>https://raw.githubusercontent.com/firebase/firebase-ios-sdk/674d9a7ee9858207181a3dd0b42c77298c6fb71b/Crashlytics/upload-symbols</Url>
       <ToFile>$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)</ToFile>
       <Kind>Uncompressed</Kind>
     </XamarinBuildDownload>

--- a/source/Firebase/Database/Database.csproj
+++ b/source/Firebase/Database/Database.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Database</RootNamespace>
     <AssemblyName>Firebase.Database</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/InAppMessaging/InAppMessaging.csproj
+++ b/source/Firebase/InAppMessaging/InAppMessaging.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.InAppMessaging</RootNamespace>
     <AssemblyName>Firebase.InAppMessaging</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Installations/Installations.csproj
+++ b/source/Firebase/Installations/Installations.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Installations</RootNamespace>
     <AssemblyName>Firebase.Installations</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
+++ b/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.PerformanceMonitoring</RootNamespace>
     <AssemblyName>Firebase.PerformanceMonitoring</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/RemoteConfig/RemoteConfig.csproj
+++ b/source/Firebase/RemoteConfig/RemoteConfig.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.RemoteConfig</RootNamespace>
     <AssemblyName>Firebase.RemoteConfig</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Storage/Storage.csproj
+++ b/source/Firebase/Storage/Storage.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Storage</RootNamespace>
     <AssemblyName>Firebase.Storage</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Google.GoogleAppMeasurement</RootNamespace>
     <AssemblyName>Google.GoogleAppMeasurement</AssemblyName>
-    <AssemblyVersion>12.7.0</AssemblyVersion>
-    <FileVersion>12.7.0</FileVersion>
+    <AssemblyVersion>12.8.0</AssemblyVersion>
+    <FileVersion>12.8.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.7.0</PackageVersion>
+    <PackageVersion>12.8.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_GoogleAppMeasurementAssemblyName>Google.GoogleAppMeasurement, Version=12.7.0, Culture=neutral, PublicKeyToken=null</_GoogleAppMeasurementAssemblyName>
+    <_GoogleAppMeasurementAssemblyName>Google.GoogleAppMeasurement, Version=12.8.0, Culture=neutral, PublicKeyToken=null</_GoogleAppMeasurementAssemblyName>
   </PropertyGroup>
 </Project>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
@@ -20,8 +20,8 @@
     <RuntimeDriftCasePropsPath></RuntimeDriftCasePropsPath>
     <BindingSurfaceCoverageTarget></BindingSurfaceCoverageTarget>
     <BindingSurfaceCoveragePropsPath></BindingSurfaceCoveragePropsPath>
-    <FirebasePackageVersion>12.7.0</FirebasePackageVersion>
-    <GoogleAppMeasurementPackageVersion>12.7.0</GoogleAppMeasurementPackageVersion>
+    <FirebasePackageVersion>12.8.0</FirebasePackageVersion>
+    <GoogleAppMeasurementPackageVersion>12.8.0</GoogleAppMeasurementPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(RuntimeDriftCasePropsPath)" Condition="'$(RuntimeDriftCasePropsPath)' != '' and Exists('$(RuntimeDriftCasePropsPath)')" />

--- a/tests/E2E/Firebase.Foundation/README.md
+++ b/tests/E2E/Firebase.Foundation/README.md
@@ -95,7 +95,7 @@ tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug 
 
 ## Binding surface coverage mode
 
-The opt-in binding surface coverage lane accounts for the active Firebase `12.7.0` bindings tracked by the audit config. It generates a source-derived coverage inventory from [`binding-surface-coverage.json`](./binding-surface-coverage.json), restores the selected target package set from the local feed, and runs `ConfigureApp` plus the generated surface coverage case.
+The opt-in binding surface coverage lane accounts for the active Firebase `12.8.0` bindings tracked by the audit config. It generates a source-derived coverage inventory from [`binding-surface-coverage.json`](./binding-surface-coverage.json), restores the selected target package set from the local feed, and runs `ConfigureApp` plus the generated surface coverage case.
 
 This lane treats native Firebase/backend errors as acceptable when the binding surface is present and loadable. It fails binding-layer problems such as missing managed types, missing Objective-C classes/protocols/selectors, missing native symbols, `TypeLoadException`, `DllNotFoundException`, `EntryPointNotFoundException`, and `ObjCRuntime.ObjCException`.
 

--- a/tests/E2E/Firebase.Foundation/binding-surface-coverage.json
+++ b/tests/E2E/Firebase.Foundation/binding-surface-coverage.json
@@ -52,7 +52,7 @@
       "requiredExtraPackages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -165,7 +165,7 @@
       "requiredExtraPackages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -25,7 +25,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.AppCheck",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -36,11 +36,11 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.RemoteConfig",
-          "version": "12.7.0"
+          "version": "12.8.0"
         },
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -51,7 +51,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Database",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -62,7 +62,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Database",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -73,7 +73,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -84,7 +84,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -95,7 +95,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -106,7 +106,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -117,7 +117,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -128,7 +128,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -139,7 +139,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -150,7 +150,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -161,7 +161,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -172,7 +172,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -183,7 +183,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -194,7 +194,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFunctions",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -205,7 +205,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Crashlytics",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     },
@@ -216,7 +216,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Crashlytics",
-          "version": "12.7.0"
+          "version": "12.8.0"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Bump the Firebase binding line and GoogleAppMeasurement package metadata from 12.7.0 to 12.8.0.
- Update Firebase 12.8 CocoaPods pins, external download metadata, project/package versions, targets metadata, Crashlytics upload-symbols URL, and E2E/audit package metadata.
- Bind the new Firestore pipeline bridge surface from `FIRPipelineBridge.h` and add narrow audit suppressions for the existing Firestore Sharpie wrapper-generation limitation.
- Update the root README, Firebase NuGet readmes, and E2E README so publish-visible docs advertise 12.8.0.

## Validation

- `dotnet cake --target=firebase-release-check --firebase-version=12.8.0`
- `scripts/compare-firebase-bindings.sh --output-dir output/firebase-binding-audit-12.8`
- `dotnet test scripts/FirebaseBindingAudit.Tests/FirebaseBindingAudit.Tests.csproj -v minimal`
- `dotnet build source/Firebase/CloudFirestore/CloudFirestore.csproj -c Release -v minimal /p:RestoreAdditionalProjectSources=/Users/adam/RiderProjects/GoogleApisForiOSComponents/output`
- `dotnet pack source/Firebase/CloudFirestore/CloudFirestore.csproj -c Release -v minimal -o output /p:RestoreAdditionalProjectSources=/Users/adam/RiderProjects/GoogleApisForiOSComponents/output`
- `rg -n "12\\.7\\.0" Readme.md docs/Firebase/NuGet tests/E2E/Firebase.Foundation/README.md` returned no matches.

## Notes

CloudFirestore still reports a failed Sharpie pass in the binding audit, matching the existing wrapper-module limitation. The new pipeline bridge suppressions are scoped to the exact C# type/delegate and native comparison key for each declaration added from `FIRPipelineBridge.h`.