### PR TITLE
[codex] Prepare Firebase 12.10 bindings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -143,7 +143,7 @@ If your project targets multiple platforms, keep these packages inside Apple-onl
 
 ```xml
 <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.9.0" />
+  <PackageReference Include="AdamE.Firebase.iOS.Core" Version="12.10.0" />
 </ItemGroup>
 ```
 
@@ -167,7 +167,7 @@ Archiving can still be more reliable on macOS or from the command line.
 
 The lists below reflect what is currently published on [nuget.org](https://www.nuget.org/profiles/adamessenmacher) under the `adamessenmacher` owner profile. That is intentionally different from the repo state in [`components.cake`](components.cake): the repo can contain projects or version bumps that have not been published yet.
 
-Firebase `12.9.0` is the current published Firebase package line.
+Firebase `12.10.0` is the current published Firebase package line.
 
 ### Currently published on nuget.org
 
@@ -175,22 +175,22 @@ Firebase `12.9.0` is the current published Firebase package line.
 
 | Package | Version |
 | --- | --- |
-| `ABTesting` | `12.9.0` |
-| `Analytics` | `12.9.0` |
-| `AppCheck` | `12.9.0` |
-| `AppDistribution` | `12.9.0` |
-| `Auth` | `12.9.0` |
-| `CloudFirestore` | `12.9.0` |
-| `CloudFunctions` | `12.9.0` |
-| `CloudMessaging` | `12.9.0` |
-| `Core` | `12.9.0` |
-| `Crashlytics` | `12.9.0` |
-| `Database` | `12.9.0` |
-| `InAppMessaging` | `12.9.0` |
-| `Installations` | `12.9.0` |
-| `PerformanceMonitoring` | `12.9.0` |
-| `RemoteConfig` | `12.9.0` |
-| `Storage` | `12.9.0` |
+| `ABTesting` | `12.10.0` |
+| `Analytics` | `12.10.0` |
+| `AppCheck` | `12.10.0` |
+| `AppDistribution` | `12.10.0` |
+| `Auth` | `12.10.0` |
+| `CloudFirestore` | `12.10.0` |
+| `CloudFunctions` | `12.10.0` |
+| `CloudMessaging` | `12.10.0` |
+| `Core` | `12.10.0` |
+| `Crashlytics` | `12.10.0` |
+| `Database` | `12.10.0` |
+| `InAppMessaging` | `12.10.0` |
+| `Installations` | `12.10.0` |
+| `PerformanceMonitoring` | `12.10.0` |
+| `RemoteConfig` | `12.10.0` |
+| `Storage` | `12.10.0` |
 
 #### Google packages (`AdamE.Google.iOS.*`)
 
@@ -207,7 +207,7 @@ These packages are usually consumed transitively rather than referenced directly
 | Package | Version |
 | --- | --- |
 | `AppCheckCore` | `11.2.0` |
-| `GoogleAppMeasurement` | `12.9.0` |
+| `GoogleAppMeasurement` | `12.10.0` |
 | `GoogleDataTransport` | `10.1.0.5` |
 | `GoogleUtilities` | `8.1.0.3` |
 | `Nanopb` | `3.30910.0.5` |

--- a/components.cake
+++ b/components.cake
@@ -1,20 +1,20 @@
 // Firebase artifacts available to be built. These artifacts generate NuGets.
-Artifact FIREBASE_AB_TESTING_ARTIFACT              = new Artifact ("Firebase.ABTesting",              "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "ABTesting");
-Artifact FIREBASE_ANALYTICS_ARTIFACT               = new Artifact ("Firebase.Analytics",              "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "Analytics");
-Artifact FIREBASE_AUTH_ARTIFACT                    = new Artifact ("Firebase.Auth",                   "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "Auth");
-Artifact FIREBASE_CLOUD_FIRESTORE_ARTIFACT         = new Artifact ("Firebase.CloudFirestore",         "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFirestore");
-Artifact FIREBASE_CLOUD_FUNCTIONS_ARTIFACT         = new Artifact ("Firebase.CloudFunctions",         "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFunctions");
-Artifact FIREBASE_CLOUD_MESSAGING_ARTIFACT         = new Artifact ("Firebase.CloudMessaging",         "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudMessaging");
-Artifact FIREBASE_CORE_ARTIFACT                    = new Artifact ("Firebase.Core",                   "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "Core");
-Artifact FIREBASE_CRASHLYTICS_ARTIFACT             = new Artifact ("Firebase.Crashlytics",            "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "Crashlytics");
-Artifact FIREBASE_DATABASE_ARTIFACT                = new Artifact ("Firebase.Database",               "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "Database");
-Artifact FIREBASE_IN_APP_MESSAGING_ARTIFACT        = new Artifact ("Firebase.InAppMessaging",         "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "InAppMessaging");
-Artifact FIREBASE_INSTALLATIONS_ARTIFACT           = new Artifact ("Firebase.Installations",          "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "Installations");
-Artifact FIREBASE_PERFORMANCE_MONITORING_ARTIFACT  = new Artifact ("Firebase.PerformanceMonitoring",  "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "PerformanceMonitoring");
-Artifact FIREBASE_REMOTE_CONFIG_ARTIFACT           = new Artifact ("Firebase.RemoteConfig",           "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "RemoteConfig");
-Artifact FIREBASE_STORAGE_ARTIFACT                 = new Artifact ("Firebase.Storage",                "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "Storage");
-Artifact FIREBASE_APP_DISTRIBUTION_ARTIFACT        = new Artifact ("Firebase.AppDistribution",        "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppDistribution");
-Artifact FIREBASE_APP_CHECK_ARTIFACT               = new Artifact ("Firebase.AppCheck",               "12.9.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppCheck");
+Artifact FIREBASE_AB_TESTING_ARTIFACT              = new Artifact ("Firebase.ABTesting",              "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "ABTesting");
+Artifact FIREBASE_ANALYTICS_ARTIFACT               = new Artifact ("Firebase.Analytics",              "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "Analytics");
+Artifact FIREBASE_AUTH_ARTIFACT                    = new Artifact ("Firebase.Auth",                   "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "Auth");
+Artifact FIREBASE_CLOUD_FIRESTORE_ARTIFACT         = new Artifact ("Firebase.CloudFirestore",         "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFirestore");
+Artifact FIREBASE_CLOUD_FUNCTIONS_ARTIFACT         = new Artifact ("Firebase.CloudFunctions",         "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudFunctions");
+Artifact FIREBASE_CLOUD_MESSAGING_ARTIFACT         = new Artifact ("Firebase.CloudMessaging",         "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "CloudMessaging");
+Artifact FIREBASE_CORE_ARTIFACT                    = new Artifact ("Firebase.Core",                   "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "Core");
+Artifact FIREBASE_CRASHLYTICS_ARTIFACT             = new Artifact ("Firebase.Crashlytics",            "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "Crashlytics");
+Artifact FIREBASE_DATABASE_ARTIFACT                = new Artifact ("Firebase.Database",               "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "Database");
+Artifact FIREBASE_IN_APP_MESSAGING_ARTIFACT        = new Artifact ("Firebase.InAppMessaging",         "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "InAppMessaging");
+Artifact FIREBASE_INSTALLATIONS_ARTIFACT           = new Artifact ("Firebase.Installations",          "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "Installations");
+Artifact FIREBASE_PERFORMANCE_MONITORING_ARTIFACT  = new Artifact ("Firebase.PerformanceMonitoring",  "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "PerformanceMonitoring");
+Artifact FIREBASE_REMOTE_CONFIG_ARTIFACT           = new Artifact ("Firebase.RemoteConfig",           "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "RemoteConfig");
+Artifact FIREBASE_STORAGE_ARTIFACT                 = new Artifact ("Firebase.Storage",                "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "Storage");
+Artifact FIREBASE_APP_DISTRIBUTION_ARTIFACT        = new Artifact ("Firebase.AppDistribution",        "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppDistribution");
+Artifact FIREBASE_APP_CHECK_ARTIFACT               = new Artifact ("Firebase.AppCheck",               "12.10.0",  "15.0", ComponentGroup.Firebase, csprojName: "AppCheck");
 
 // Google artifacts available to be built. These artifacts generate NuGets.
 Artifact GOOGLE_ANALYTICS_ARTIFACT                 = new Artifact ("Google.Analytics",                "3.20.0.2",  "15.0", ComponentGroup.Google, csprojName: "Analytics");
@@ -26,7 +26,7 @@ Artifact GOOGLE_APP_CHECK_CORE_ARTIFACT            = new Artifact ("Google.AppCh
 Artifact GOOGLE_SIGN_IN_ARTIFACT                   = new Artifact ("Google.SignIn",                   "9.0.0.0",   "15.0", ComponentGroup.Google, csprojName: "SignIn");
 Artifact GOOGLE_TAG_MANAGER_ARTIFACT               = new Artifact ("Google.TagManager",               "7.4.0.2",   "15.0", ComponentGroup.Google, csprojName: "TagManager");
 
-Artifact GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT    = new Artifact ("Google.AppMeasurement",           "12.9.0",      "15.0", ComponentGroup.Google, csprojName: "GoogleAppMeasurement");
+Artifact GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT    = new Artifact ("Google.AppMeasurement",           "12.10.0",      "15.0", ComponentGroup.Google, csprojName: "GoogleAppMeasurement");
 Artifact GOOGLE_PROMISES_OBJC_ARTIFACT             = new Artifact ("Google.PromisesObjC",             "2.4.0.5",     "15.0", ComponentGroup.Google, csprojName: "PromisesObjC");
 Artifact GOOGLE_GTM_SESSION_FETCHER_ARTIFACT       = new Artifact ("Google.GTMSessionFetcher",        "3.5.0.5",     "15.0", ComponentGroup.Google, csprojName: "GTMSessionFetcher");
 Artifact GOOGLE_NANOPB_ARTIFACT                    = new Artifact ("Google.Nanopb",                   "3.30910.0.5", "15.0", ComponentGroup.Google, csprojName: "Nanopb");
@@ -148,68 +148,68 @@ void SetArtifactsPodSpecs ()
 {
 	// Firebase components
 	FIREBASE_AB_TESTING_ARTIFACT.PodSpecs = new [] { 
-		PodSpec.Create ("FirebaseABTesting", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseABTesting", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_ANALYTICS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAnalytics", "12.9.0")
+		PodSpec.Create ("FirebaseAnalytics", "12.10.0")
 	};
 	FIREBASE_AUTH_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAuth",     "12.9.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseAuth",     "12.10.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("RecaptchaInterop", "101.0.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CLOUD_FIRESTORE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseFirestore",         "12.9.0",       frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseFirestoreInternal", "12.9.0",       frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseFirestore",         "12.10.0",       frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseFirestoreInternal", "12.10.0",       frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("BoringSSL-GRPC",            "0.0.37",       frameworkSource: FrameworkSource.Pods, frameworkName: "openssl_grpc"),
 		PodSpec.Create ("gRPC-Core",                 "1.69.0",       frameworkSource: FrameworkSource.Pods, frameworkName: "grpc"),
 		PodSpec.Create ("gRPC-C++",                  "1.69.0",       frameworkSource: FrameworkSource.Pods, frameworkName: "grpcpp"),
 		PodSpec.Create ("abseil",                    "1.20240722.0", frameworkSource: FrameworkSource.Pods, frameworkName: "absl", subSpecs: new [] { "algorithm", "base", "memory", "meta", "strings", "time", "types" }),
 	};
 	FIREBASE_CLOUD_FUNCTIONS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseFunctions", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseFunctions", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CLOUD_MESSAGING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseMessaging", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseMessaging", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_CORE_ARTIFACT.PodSpecs = new [] {
-	    PodSpec.Create ("FirebaseAppCheckInterop",     "12.9.0", frameworkSource: FrameworkSource.Pods),
-	    PodSpec.Create ("FirebaseAuthInterop",         "12.9.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCore",                "12.9.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCoreExtension",       "12.9.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseCoreInternal",        "12.9.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseMessagingInterop",    "12.9.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.9.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseSharedSwift",         "12.9.0", frameworkSource: FrameworkSource.Pods),
+	    PodSpec.Create ("FirebaseAppCheckInterop",     "12.10.0", frameworkSource: FrameworkSource.Pods),
+	    PodSpec.Create ("FirebaseAuthInterop",         "12.10.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCore",                "12.10.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCoreExtension",       "12.10.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseCoreInternal",        "12.10.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseMessagingInterop",    "12.10.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseRemoteConfigInterop", "12.10.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseSharedSwift",         "12.10.0", frameworkSource: FrameworkSource.Pods),
 		PodSpec.Create ("PromisesSwift",               "2.4.0",  frameworkSource: FrameworkSource.Pods, frameworkName: "Promises", targetName: "PromisesSwift"),
 		PodSpec.Create ("leveldb-library",             "1.22.6", frameworkSource: FrameworkSource.Pods, frameworkName: "leveldb"),
 	};
 	FIREBASE_CRASHLYTICS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseCrashlytics", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseCrashlytics", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_DATABASE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseDatabase", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseDatabase", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_IN_APP_MESSAGING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("Firebase", "12.9.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
+		PodSpec.Create ("Firebase", "12.10.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseInAppMessaging", targetName: "FirebaseInAppMessaging", subSpecs: new [] { "InAppMessaging" })
 	};
 	FIREBASE_INSTALLATIONS_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseInstallations", "12.9.0", frameworkSource: FrameworkSource.Pods),
-		PodSpec.Create ("FirebaseSessions",      "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseInstallations", "12.10.0", frameworkSource: FrameworkSource.Pods),
+		PodSpec.Create ("FirebaseSessions",      "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_PERFORMANCE_MONITORING_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebasePerformance", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebasePerformance", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_REMOTE_CONFIG_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseRemoteConfig", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseRemoteConfig", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_STORAGE_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseStorage", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseStorage", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 	FIREBASE_APP_DISTRIBUTION_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("Firebase", "12.9.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseAppDistribution", targetName: "FirebaseAppDistribution", subSpecs: new [] { "AppDistribution" })
+		PodSpec.Create ("Firebase", "12.10.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FirebaseAppDistribution", targetName: "FirebaseAppDistribution", subSpecs: new [] { "AppDistribution" })
 	};
 	FIREBASE_APP_CHECK_ARTIFACT.PodSpecs = new [] {
-		PodSpec.Create ("FirebaseAppCheck", "12.9.0", frameworkSource: FrameworkSource.Pods)
+		PodSpec.Create ("FirebaseAppCheck", "12.10.0", frameworkSource: FrameworkSource.Pods)
 	};
 
 	// Google components
@@ -240,7 +240,7 @@ void SetArtifactsPodSpecs ()
 		PodSpec.Create ("GoogleTagManager", "7.4.0")
 	};
     GOOGLE_GOOGLE_APP_MEASUREMENT_ARTIFACT.PodSpecs = new [] {
-        PodSpec.Create ("GoogleAppMeasurement", "12.9.0")
+        PodSpec.Create ("GoogleAppMeasurement", "12.10.0")
     };
 	GOOGLE_PROMISES_OBJC_ARTIFACT.PodSpecs = new [] {
 	    PodSpec.Create ("PromisesObjC", "2.4.0", frameworkSource: FrameworkSource.Pods, frameworkName: "FBLPromises", targetName: "PromisesObjC"),

--- a/custom_externals_download.cake
+++ b/custom_externals_download.cake
@@ -20,8 +20,8 @@ class ExternalDownloadSource
 // FirebaseAnalytics: https://github.com/CocoaPods/Specs/tree/master/Specs/e/2/1/FirebaseAnalytics
 // GoogleAppMeasurement: https://github.com/CocoaPods/Specs/tree/master/Specs/e/3/b/GoogleAppMeasurement
 var ExternalDownloads = new Dictionary<string, ExternalDownloadSource> {
-	{ "FirebaseAnalytics", new ExternalDownloadSource ("FirebaseAnalytics", "12.8.0", "3b57be475bd21097") },
-	{ "GoogleAppMeasurement", new ExternalDownloadSource ("GoogleAppMeasurement", "12.8.0", "48879432478c47b8") },
+	{ "FirebaseAnalytics", new ExternalDownloadSource ("FirebaseAnalytics", "12.10.0", "3c185b45848d98d8") },
+	{ "GoogleAppMeasurement", new ExternalDownloadSource ("GoogleAppMeasurement", "12.10.0", "5f5e4d8cb469941e") },
 };
 
 FilePath GetArchivePath (ExternalDownloadSource source, DirectoryPath externalsPath) =>

--- a/scripts/FirebaseBindingAudit/BindingSurfaceCoverage.cs
+++ b/scripts/FirebaseBindingAudit/BindingSurfaceCoverage.cs
@@ -10,7 +10,7 @@ namespace FirebaseBindingAudit;
 
 internal static class FirebasePackageVersions
 {
-    public const string DefaultFirebasePackageVersion = "12.9.0";
+    public const string DefaultFirebasePackageVersion = "12.10.0";
 }
 
 internal sealed class BindingSurfaceCoverageManifest

--- a/source/Firebase/ABTesting/ABTesting.csproj
+++ b/source/Firebase/ABTesting/ABTesting.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.ABTesting</RootNamespace>
     <AssemblyName>Firebase.ABTesting</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Analytics/Analytics.csproj
+++ b/source/Firebase/Analytics/Analytics.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Analytics</RootNamespace>
     <AssemblyName>Firebase.Analytics</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProcessEnums>true</ProcessEnums>
@@ -28,7 +28,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />
@@ -57,7 +57,7 @@
     <ObjcBindingApiDefinition Include="Enums.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AdamE.Google.iOS.GoogleAppMeasurement" Version="12.9.0" />
+    <PackageReference Include="AdamE.Google.iOS.GoogleAppMeasurement" Version="12.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" PrivateAssets="None" />

--- a/source/Firebase/Analytics/Analytics.targets
+++ b/source/Firebase/Analytics/Analytics.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=12.9.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
+    <_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/AppCheck/AppCheck.csproj
+++ b/source/Firebase/AppCheck/AppCheck.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.AppCheck</RootNamespace>
     <AssemblyName>Firebase.AppCheck</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/AppCheck/AppCheck.targets
+++ b/source/Firebase/AppCheck/AppCheck.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseAppCheckAssemblyName>Firebase.AppCheck, Version=12.9.0, Culture=neutral, PublicKeyToken=null</_FirebaseAppCheckAssemblyName>
+    <_FirebaseAppCheckAssemblyName>Firebase.AppCheck, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_FirebaseAppCheckAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/AppDistribution/AppDistribution.csproj
+++ b/source/Firebase/AppDistribution/AppDistribution.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.AppDistribution</RootNamespace>
     <AssemblyName>Firebase.AppDistribution</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Auth/Auth.csproj
+++ b/source/Firebase/Auth/Auth.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Auth</RootNamespace>
     <AssemblyName>Firebase.Auth</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudFirestore/CloudFirestore.csproj
+++ b/source/Firebase/CloudFirestore/CloudFirestore.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudFirestore</RootNamespace>
     <AssemblyName>Firebase.CloudFirestore</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudFunctions/CloudFunctions.csproj
+++ b/source/Firebase/CloudFunctions/CloudFunctions.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudFunctions</RootNamespace>
     <AssemblyName>Firebase.CloudFunctions</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/CloudMessaging/CloudMessaging.csproj
+++ b/source/Firebase/CloudMessaging/CloudMessaging.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.CloudMessaging</RootNamespace>
     <AssemblyName>Firebase.CloudMessaging</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Core</RootNamespace>
     <AssemblyName>Firebase.Core</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Core/Core.targets
+++ b/source/Firebase/Core/Core.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_FirebaseCoreAssemblyName>Firebase.Core, Version=12.9.0, Culture=neutral, PublicKeyToken=null</_FirebaseCoreAssemblyName>
+    <_FirebaseCoreAssemblyName>Firebase.Core, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_FirebaseCoreAssemblyName>
   </PropertyGroup>
 </Project>

--- a/source/Firebase/Crashlytics/Crashlytics.csproj
+++ b/source/Firebase/Crashlytics/Crashlytics.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Crashlytics</RootNamespace>
     <AssemblyName>Firebase.Crashlytics</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Crashlytics/Crashlytics.targets
+++ b/source/Firebase/Crashlytics/Crashlytics.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <_FirebaseCrashlyticsAssemblyName>Firebase.Crashlytics, Version=12.9.0, Culture=neutral, PublicKeyToken=null</_FirebaseCrashlyticsAssemblyName>
-    <_FirebaseCrashlyticsItemsFolder>FCrshlytcs-12.9.0</_FirebaseCrashlyticsItemsFolder>
+    <_FirebaseCrashlyticsAssemblyName>Firebase.Crashlytics, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_FirebaseCrashlyticsAssemblyName>
+    <_FirebaseCrashlyticsItemsFolder>FCrshlytcs-12.10.0</_FirebaseCrashlyticsItemsFolder>
     <_FirebaseCrashlyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseCrashlyticsItemsFolder)\</_FirebaseCrashlyticsSDKBaseFolder>
     <!-- Requires a file extension, otherwise XDB will complain  -->
     <_FirebaseScriptName>upload-symbols.sh</_FirebaseScriptName>
@@ -22,7 +22,7 @@
   <ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
     <XamarinBuildDownload Include="$(_FirebaseCrashlyticsItemsFolder)">
       <!-- To upgrade, change commit id from the appropriate tag: https://github.com/firebase/firebase-ios-sdk/tags-->
-      <Url>https://raw.githubusercontent.com/firebase/firebase-ios-sdk/9b3aed4fa6226125305b82d4d86c715bef250785/Crashlytics/upload-symbols</Url>
+      <Url>https://raw.githubusercontent.com/firebase/firebase-ios-sdk/85560b48b0ff099ad83fe53d67df3c67fbc2b7a6/Crashlytics/upload-symbols</Url>
       <ToFile>$(_FirebaseCrashlyticsSDKBaseFolder)$(_FirebaseScriptName)</ToFile>
       <Kind>Uncompressed</Kind>
     </XamarinBuildDownload>

--- a/source/Firebase/Database/Database.csproj
+++ b/source/Firebase/Database/Database.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Database</RootNamespace>
     <AssemblyName>Firebase.Database</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/InAppMessaging/InAppMessaging.csproj
+++ b/source/Firebase/InAppMessaging/InAppMessaging.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.InAppMessaging</RootNamespace>
     <AssemblyName>Firebase.InAppMessaging</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Installations/Installations.csproj
+++ b/source/Firebase/Installations/Installations.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Installations</RootNamespace>
     <AssemblyName>Firebase.Installations</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
+++ b/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.PerformanceMonitoring</RootNamespace>
     <AssemblyName>Firebase.PerformanceMonitoring</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/RemoteConfig/RemoteConfig.csproj
+++ b/source/Firebase/RemoteConfig/RemoteConfig.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.RemoteConfig</RootNamespace>
     <AssemblyName>Firebase.RemoteConfig</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Firebase/Storage/Storage.csproj
+++ b/source/Firebase/Storage/Storage.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Firebase.Storage</RootNamespace>
     <AssemblyName>Firebase.Storage</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -27,7 +27,7 @@
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
@@ -8,8 +8,8 @@
     <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     <RootNamespace>Google.GoogleAppMeasurement</RootNamespace>
     <AssemblyName>Google.GoogleAppMeasurement</AssemblyName>
-    <AssemblyVersion>12.9.0</AssemblyVersion>
-    <FileVersion>12.9.0</FileVersion>
+    <AssemblyVersion>12.10.0</AssemblyVersion>
+    <FileVersion>12.10.0</FileVersion>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://github.com/AdamEssenmacher/GoogleApisForiOSComponents</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>12.9.0</PackageVersion>
+    <PackageVersion>12.10.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.cs" />

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <_GoogleAppMeasurementAssemblyName>Google.GoogleAppMeasurement, Version=12.9.0, Culture=neutral, PublicKeyToken=null</_GoogleAppMeasurementAssemblyName>
+    <_GoogleAppMeasurementAssemblyName>Google.GoogleAppMeasurement, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_GoogleAppMeasurementAssemblyName>
   </PropertyGroup>
 </Project>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
@@ -21,8 +21,8 @@
     <RuntimeDriftCasePropsPath></RuntimeDriftCasePropsPath>
     <BindingSurfaceCoverageTarget></BindingSurfaceCoverageTarget>
     <BindingSurfaceCoveragePropsPath></BindingSurfaceCoveragePropsPath>
-    <FirebasePackageVersion>12.9.0</FirebasePackageVersion>
-    <GoogleAppMeasurementPackageVersion>12.9.0</GoogleAppMeasurementPackageVersion>
+    <FirebasePackageVersion>12.10.0</FirebasePackageVersion>
+    <GoogleAppMeasurementPackageVersion>12.10.0</GoogleAppMeasurementPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(RuntimeDriftCasePropsPath)" Condition="'$(RuntimeDriftCasePropsPath)' != '' and Exists('$(RuntimeDriftCasePropsPath)')" />

--- a/tests/E2E/Firebase.Foundation/README.md
+++ b/tests/E2E/Firebase.Foundation/README.md
@@ -96,7 +96,7 @@ tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug 
 
 ## Binding surface coverage mode
 
-The opt-in binding surface coverage lane accounts for the active Firebase `12.9.0` bindings tracked by the audit config. It generates a source-derived coverage inventory from [`binding-surface-coverage.json`](./binding-surface-coverage.json), restores the selected target package set from the local feed, and runs `ConfigureApp` plus the generated surface coverage case.
+The opt-in binding surface coverage lane accounts for the active Firebase `12.10.0` bindings tracked by the audit config. It generates a source-derived coverage inventory from [`binding-surface-coverage.json`](./binding-surface-coverage.json), restores the selected target package set from the local feed, and runs `ConfigureApp` plus the generated surface coverage case.
 
 This lane treats native Firebase/backend errors as acceptable when the binding surface is present and loadable. It fails binding-layer problems such as missing managed types, missing Objective-C classes/protocols/selectors, missing native symbols, `TypeLoadException`, `DllNotFoundException`, `EntryPointNotFoundException`, and `ObjCRuntime.ObjCException`.
 

--- a/tests/E2E/Firebase.Foundation/binding-surface-coverage.json
+++ b/tests/E2E/Firebase.Foundation/binding-surface-coverage.json
@@ -52,7 +52,7 @@
       "requiredExtraPackages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -165,7 +165,7 @@
       "requiredExtraPackages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },

--- a/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
+++ b/tests/E2E/Firebase.Foundation/runtime-drift-cases.json
@@ -25,7 +25,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.AppCheck",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -36,11 +36,11 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.RemoteConfig",
-          "version": "12.9.0"
+          "version": "12.10.0"
         },
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -51,7 +51,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Database",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -62,7 +62,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Database",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -73,7 +73,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -84,7 +84,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -95,7 +95,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.ABTesting",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -106,7 +106,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -117,7 +117,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -128,7 +128,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -139,7 +139,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -150,7 +150,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -161,7 +161,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -172,7 +172,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -183,7 +183,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFirestore",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -194,7 +194,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.CloudFunctions",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -205,7 +205,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Crashlytics",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     },
@@ -216,7 +216,7 @@
       "packages": [
         {
           "id": "AdamE.Firebase.iOS.Crashlytics",
-          "version": "12.9.0"
+          "version": "12.10.0"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- bump the Firebase binding package line to `12.10.0`
- bump `AdamE.Google.iOS.GoogleAppMeasurement` to `12.10.0`
- update publish metadata, E2E package versions, and publish-facing docs to match the new line
- update analytics tarball download metadata and the Crashlytics `upload-symbols` source URL for the upstream `12.10.0` release

## Why
Firebase Apple SDK `12.10.0` is the next package line. This repo needs the deterministic version/config updates so the bindings, E2E validation, and published package metadata stay aligned with the upstream release.

## Validation
- `dotnet tool run dotnet-cake -- --target=firebase-release-check --firebase-version=12.10.0`
- `dotnet test scripts/FirebaseBindingAudit.Tests/FirebaseBindingAudit.Tests.csproj`
- `scripts/compare-firebase-bindings.sh --output-dir output/firebase-binding-audit-12.10`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --enable-nullability-validation`
- `tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --binding-surface-target all`
- `E2E_TIMEOUT_SECONDS=300 tools/e2e/run-firebase-foundation.sh --package-dir output --configuration Debug --runtime-drift-case all`

## Notes
- binding audit reported `0` unsuppressed failures for the staged `12.10` externals
- full E2E validation passed against the `12.10.0` packages in `output/`
- public release notes did not indicate additional manual binding work beyond the version/config updates in this PR