### PR TITLE
[codex] Fail fast on XCFramework creation errors

### DIFF
--- a/common.cake
+++ b/common.cake
@@ -624,7 +624,7 @@ void BuildXcodeXcframework (FilePath xcodeProject, PodSpec [] podSpecs, Platform
 		}
 
 		Information ($"Building {podSpec.FrameworkName} xcframework...");
-		StartProcess("xcodebuild", new ProcessSettings { Arguments = xcodeBuildArgs });
+		ThrowIfProcessFailed ("xcodebuild -create-xcframework", StartProcess ("xcodebuild", new ProcessSettings { Arguments = xcodeBuildArgs }));
 	}
 }
 


### PR DESCRIPTION
## Summary
- wrap the final `xcodebuild -create-xcframework` call in `ThrowIfProcessFailed`
- make the failing step explicit in Cake logs with an `xcodebuild -create-xcframework` label

## Why
`BuildXcodeXcframework` was discarding the exit code from the final XCFramework assembly step. That let Cake continue after a failed `xcodebuild -create-xcframework`, which could reuse stale output from `externals/` and package the wrong native artifacts.

## Impact
Cake now exits immediately when XCFramework creation fails during the `externals` step.

## Validation
- `dotnet tool restore`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Google.SignIn`