### PR TITLE
Target .NET 10 only

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -119,7 +119,7 @@ dotnet tool run dotnet-cake -- --target=nuget --names=Google.SignIn
 
 ## Installation and usage notes
 
-These packages are intended for Apple TFMs such as `net9.0-ios`, `net10.0-ios`, and their Mac Catalyst equivalents.
+These packages target `net10.0-ios` and `net10.0-maccatalyst`. .NET 9 is no longer supported.
 
 ### `Firebase.Installations` may need an explicit reference
 
@@ -222,7 +222,7 @@ These packages are usually consumed transitively rather than referenced directly
 
 ### Published on nuget.org, but older / legacy package lines
 
-These packages are still published on nuget.org, but they are not part of the current .NET 9 / .NET 10 publishing wave:
+These packages are still published on nuget.org, but they are not part of the current .NET 10 publishing wave:
 
 - `AdamE.Firebase.iOS.DynamicLinks` `11.15.0`
 - `AdamE.Google.iOS.GTMSessionFetcher` `4.3.0`

--- a/docs/Firebase/NuGet/ABTesting.md
+++ b/docs/Firebase/NuGet/ABTesting.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/Analytics.md
+++ b/docs/Firebase/NuGet/Analytics.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/AppCheck.md
+++ b/docs/Firebase/NuGet/AppCheck.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/AppDistribution.md
+++ b/docs/Firebase/NuGet/AppDistribution.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/Auth.md
+++ b/docs/Firebase/NuGet/Auth.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/CloudFirestore.md
+++ b/docs/Firebase/NuGet/CloudFirestore.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/CloudFunctions.md
+++ b/docs/Firebase/NuGet/CloudFunctions.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/CloudMessaging.md
+++ b/docs/Firebase/NuGet/CloudMessaging.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/Core.md
+++ b/docs/Firebase/NuGet/Core.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/Crashlytics.md
+++ b/docs/Firebase/NuGet/Crashlytics.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/Database.md
+++ b/docs/Firebase/NuGet/Database.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/InAppMessaging.md
+++ b/docs/Firebase/NuGet/InAppMessaging.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/Installations.md
+++ b/docs/Firebase/NuGet/Installations.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/PerformanceMonitoring.md
+++ b/docs/Firebase/NuGet/PerformanceMonitoring.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/RemoteConfig.md
+++ b/docs/Firebase/NuGet/RemoteConfig.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/Firebase/NuGet/Storage.md
+++ b/docs/Firebase/NuGet/Storage.md
@@ -20,9 +20,7 @@ These packages are thin bindings over the native Firebase Apple SDK. The native 
 
 Supported target frameworks include:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition package references so they restore only for Apple targets:

--- a/docs/NUGET_README.md
+++ b/docs/NUGET_README.md
@@ -12,9 +12,7 @@ This package README covers only binding and NuGet concerns.
 
 These packages are intended for iOS and Mac Catalyst TFMs, for example:
 
-- `net9.0-ios`
 - `net10.0-ios`
-- `net9.0-maccatalyst`
 - `net10.0-maccatalyst`
 
 When multi-targeting, condition the reference so it restores only for Apple targets:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestPatch"
+    "version": "10.0.400",
+    "rollForward": "latestPatch",
+    "workloadVersion": "10.0.302.1"
   }
 }

--- a/source/Firebase/ABTesting/ABTesting.csproj
+++ b/source/Firebase/ABTesting/ABTesting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/Analytics/Analytics.csproj
+++ b/source/Firebase/Analytics/Analytics.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/AppCheck/AppCheck.csproj
+++ b/source/Firebase/AppCheck/AppCheck.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/AppDistribution/AppDistribution.csproj
+++ b/source/Firebase/AppDistribution/AppDistribution.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/Auth/Auth.csproj
+++ b/source/Firebase/Auth/Auth.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/CloudFirestore/CloudFirestore.csproj
+++ b/source/Firebase/CloudFirestore/CloudFirestore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/CloudFunctions/CloudFunctions.csproj
+++ b/source/Firebase/CloudFunctions/CloudFunctions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/CloudMessaging/CloudMessaging.csproj
+++ b/source/Firebase/CloudMessaging/CloudMessaging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/Crashlytics/Crashlytics.csproj
+++ b/source/Firebase/Crashlytics/Crashlytics.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/Database/Database.csproj
+++ b/source/Firebase/Database/Database.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/InAppMessaging/InAppMessaging.csproj
+++ b/source/Firebase/InAppMessaging/InAppMessaging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/Installations/Installations.csproj
+++ b/source/Firebase/Installations/Installations.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
+++ b/source/Firebase/PerformanceMonitoring/PerformanceMonitoring.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/RemoteConfig/RemoteConfig.csproj
+++ b/source/Firebase/RemoteConfig/RemoteConfig.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Firebase/Storage/Storage.csproj
+++ b/source/Firebase/Storage/Storage.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/Analytics/Analytics.csproj
+++ b/source/Google/Analytics/Analytics.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/AppCheckCore/AppCheckCore.csproj
+++ b/source/Google/AppCheckCore/AppCheckCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/Cast/Cast.csproj
+++ b/source/Google/Cast/Cast.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/GTMSessionFetcher/GTMSessionFetcher.csproj
+++ b/source/Google/GTMSessionFetcher/GTMSessionFetcher.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/GoogleDataTransport/GoogleDataTransport.csproj
+++ b/source/Google/GoogleDataTransport/GoogleDataTransport.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/GoogleUtilities/GoogleUtilities.csproj
+++ b/source/Google/GoogleUtilities/GoogleUtilities.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/Maps/Maps.csproj
+++ b/source/Google/Maps/Maps.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/Nanopb/Nanopb.csproj
+++ b/source/Google/Nanopb/Nanopb.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/Places/Places.csproj
+++ b/source/Google/Places/Places.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/PromisesObjC/PromisesObjC.csproj
+++ b/source/Google/PromisesObjC/PromisesObjC.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/SignIn/SignIn.csproj
+++ b/source/Google/SignIn/SignIn.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios;net9.0-maccatalyst;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/TagManager/TagManager.csproj
+++ b/source/Google/TagManager/TagManager.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/Google/UserMessagingPlatform/UserMessagingPlatform.csproj
+++ b/source/Google/UserMessagingPlatform/UserMessagingPlatform.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/BarcodeScanning/BarcodeScanning.csproj
+++ b/source/MLKit/BarcodeScanning/BarcodeScanning.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/Core/Core.csproj
+++ b/source/MLKit/Core/Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/DigitalInkRecognition/DigitalInkRecognition.csproj
+++ b/source/MLKit/DigitalInkRecognition/DigitalInkRecognition.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/FaceDetection/FaceDetection.csproj
+++ b/source/MLKit/FaceDetection/FaceDetection.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/ImageLabeling/ImageLabeling.csproj
+++ b/source/MLKit/ImageLabeling/ImageLabeling.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/ObjectDetection/ObjectDetection.csproj
+++ b/source/MLKit/ObjectDetection/ObjectDetection.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/TextRecognition/TextRecognition.csproj
+++ b/source/MLKit/TextRecognition/TextRecognition.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/TextRecognitionChinese/TextRecognitionChinese.csproj
+++ b/source/MLKit/TextRecognitionChinese/TextRecognitionChinese.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/TextRecognitionDevanagari/TextRecognitionDevanagari.csproj
+++ b/source/MLKit/TextRecognitionDevanagari/TextRecognitionDevanagari.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/TextRecognitionJapanese/TextRecognitionJapanese.csproj
+++ b/source/MLKit/TextRecognitionJapanese/TextRecognitionJapanese.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/TextRecognitionKorean/TextRecognitionKorean.csproj
+++ b/source/MLKit/TextRecognitionKorean/TextRecognitionKorean.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/TextRecognitionLatin/TextRecognitionLatin.csproj
+++ b/source/MLKit/TextRecognitionLatin/TextRecognitionLatin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/source/MLKit/Vision/Vision.csproj
+++ b/source/MLKit/Vision/Vision.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>

--- a/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
+++ b/tests/E2E/Firebase.Foundation/FirebaseFoundationE2E/FirebaseFoundationE2E.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
     <RuntimeIdentifiers Condition="!Exists('$(ProjectAssetsFile)')">iossimulator-arm64;ios-arm64;maccatalyst-arm64</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="Exists('$(ProjectAssetsFile)')"></RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
@@ -32,15 +32,15 @@
     <DefineConstants>$(DefineConstants);ENABLE_NULLABILITY_VALIDATION</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-ios' and '$(Platform)' == ''">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios' and '$(Platform)' == ''">
     <Platform>iPhoneSimulator</Platform>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-ios' and '$(RuntimeIdentifier)' == ''">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios' and '$(RuntimeIdentifier)' == ''">
     <RuntimeIdentifier>iossimulator-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-maccatalyst' and '$(RuntimeIdentifier)' == ''">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-maccatalyst' and '$(RuntimeIdentifier)' == ''">
     <RuntimeIdentifier>maccatalyst-arm64</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/tools/e2e/run-firebase-foundation.sh
+++ b/tools/e2e/run-firebase-foundation.sh
@@ -340,7 +340,7 @@ dotnet restore "$project_file" --configfile "$restore_config" --packages "$packa
 echo "Cleaning FirebaseFoundationE2E for iOS simulator"
 dotnet clean "$project_file" \
   --configuration "$configuration" \
-  --framework net9.0-ios \
+  --framework net10.0-ios \
   -p:Platform=iPhoneSimulator \
   -p:RuntimeIdentifier=iossimulator-arm64 \
   "${msbuild_args[@]}"
@@ -348,13 +348,13 @@ dotnet clean "$project_file" \
 echo "Building FirebaseFoundationE2E for iOS simulator"
 dotnet build "$project_file" \
   --configuration "$configuration" \
-  --framework net9.0-ios \
+  --framework net10.0-ios \
   --no-restore \
   -p:Platform=iPhoneSimulator \
   -p:RuntimeIdentifier=iossimulator-arm64 \
   "${msbuild_args[@]}"
 
-app_path="$(find "$project_dir/bin" -path "*iPhoneSimulator/$configuration/net9.0-ios/iossimulator-arm64/FirebaseFoundationE2E.app" -print -quit)"
+app_path="$(find "$project_dir/bin" -path "*iPhoneSimulator/$configuration/net10.0-ios/iossimulator-arm64/FirebaseFoundationE2E.app" -print -quit)"
 if [[ ! -d "$app_path" ]]; then
   echo "Built app not found: $app_path" >&2
   exit 1


### PR DESCRIPTION
## Summary

- remove .NET 9 target frameworks from Firebase, Google, and ML Kit binding projects
- pin the .NET SDK to 10.0.400 and workload set to 10.0.302.1
- retarget the Firebase foundation E2E harness and update package documentation for .NET 10-only support

## Validation

- `dotnet tool restore`
- `dotnet tool run dotnet-cake -- --target=nuget --names=Google.SignIn`
- verified all five generated packages contain only `net10.0-ios26.0` and `net10.0-maccatalyst26.0` assets, with no .NET 9 assets
