### PR TITLE
Make XCFramework creation repeatable

### DIFF
--- a/common.cake
+++ b/common.cake
@@ -563,9 +563,10 @@ void BuildXcodeXcframework (FilePath xcodeProject, PodSpec [] podSpecs, Platform
 
 		var target = podSpec.TargetName;
 		var buildDirectory = workingDirectory.Combine (podSpec.FrameworkName);
+		var xcframeworkPath = workingDirectory.Combine ($"{podSpec.FrameworkName}.xcframework");
 		var xcodeBuildArgs = new ProcessArgumentBuilder();
 		xcodeBuildArgs.Append ("-create-xcframework");
-		xcodeBuildArgs.Append($"-output {workingDirectory}/{podSpec.FrameworkName}.xcframework");
+		xcodeBuildArgs.Append($"-output {xcframeworkPath}");
 		
 		foreach (var platform in platforms) {
 			Information ($"Building {podSpec.FrameworkName} framework with {platform.Sdk} platform SDK...");
@@ -624,6 +625,12 @@ void BuildXcodeXcframework (FilePath xcodeProject, PodSpec [] podSpecs, Platform
 		}
 
 		Information ($"Building {podSpec.FrameworkName} xcframework...");
+
+		// xcodebuild -create-xcframework fails when its output path already exists,
+		// so drop the xcframework left behind by any previous run.
+		if (DirectoryExists (xcframeworkPath))
+			DeleteDirectory (xcframeworkPath, new DeleteDirectorySettings { Recursive = true, Force = true });
+
 		ThrowIfProcessFailed ("xcodebuild -create-xcframework", StartProcess ("xcodebuild", new ProcessSettings { Arguments = xcodeBuildArgs }));
 	}
 }


### PR DESCRIPTION
## Summary

- Compute the XCFramework output path once.
- Remove an XCFramework left by a previous run before invoking `xcodebuild -create-xcframework`.
- Preserve the existing fail-fast behavior when XCFramework creation itself fails.

## Validation

- `dotnet tool restore`
- Packed Google.SignIn twice consecutively without cleaning.
- Both runs succeeded and produced all five expected NuGet packages with zero warnings and zero errors.
