### PR TITLE
Fix Crashlytics symbol upload default guard

### DIFF
--- a/source/Firebase/Crashlytics/Crashlytics.props
+++ b/source/Firebase/Crashlytics/Crashlytics.props
@@ -5,7 +5,7 @@
     This value defines if we should upload the dSYM of your app to Firebase console.
     The default value is to upload symbols only when building on Release.
     -->
-    <FirebaseCrashlyticsUploadSymbolsEnabled Condition="'$(FirebaseCrashlyticsUploadSymbolsEnabledEnabled)'=='' AND '$(Configuration)'=='Release'">True</FirebaseCrashlyticsUploadSymbolsEnabled>
+    <FirebaseCrashlyticsUploadSymbolsEnabled Condition="'$(FirebaseCrashlyticsUploadSymbolsEnabled)'=='' AND '$(Configuration)'=='Release'">True</FirebaseCrashlyticsUploadSymbolsEnabled>
     
     <!--
     This value defines if the build should continue if the dSYM upload fails.


### PR DESCRIPTION
## Summary

- correct the Crashlytics symbol-upload default guard to check the property it assigns
- preserve an explicit value supplied before the NuGet props import

## Validation

- verified a pre-set False value remains False in Release
- verified an unset Release value defaults to True
- verified an unset Debug value remains empty
- ran `dotnet tool run dotnet-cake -- --target=nuget --names=Firebase.Crashlytics` successfully with zero warnings and errors
- confirmed the corrected props file is present under both build and buildTransitive in the generated package
