### PR TITLE
Remove inert NuGet target files

### DIFF
--- a/firebase_release.cake
+++ b/firebase_release.cake
@@ -304,11 +304,7 @@ FilePath GetArtifactProjectPath (Artifact artifact)
 
 IEnumerable<FilePath> GetFirebaseReleaseTargetsFiles ()
 {
-	yield return new FilePath ("source/Firebase/Analytics/Analytics.targets");
-	yield return new FilePath ("source/Firebase/AppCheck/AppCheck.targets");
-	yield return new FilePath ("source/Firebase/Core/Core.targets");
 	yield return new FilePath ("source/Firebase/Crashlytics/Crashlytics.targets");
-	yield return new FilePath ("source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets");
 }
 
 FirebaseReleaseFileUpdate CreateFirebaseReleaseFileUpdate (string relativePath, Func<string, string> update)

--- a/source/Firebase/Analytics/Analytics.csproj
+++ b/source/Firebase/Analytics/Analytics.csproj
@@ -37,8 +37,6 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Analytics.targets" Pack="True" PackagePath="build/AdamE.Firebase.iOS.Analytics.targets" />
-    <None Include="Analytics.targets" Pack="True" PackagePath="buildTransitive/AdamE.Firebase.iOS.Analytics.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
     <None Include="../../../docs/Firebase/NuGet/Analytics.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosanalytics_128x128.png" Pack="True" PackagePath="firebaseiosanalytics_128x128.png" />

--- a/source/Firebase/Analytics/Analytics.targets
+++ b/source/Firebase/Analytics/Analytics.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Firebase/AppCheck/AppCheck.csproj
+++ b/source/Firebase/AppCheck/AppCheck.csproj
@@ -36,8 +36,6 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="AppCheck.targets" Pack="True" PackagePath="build/AdamE.Firebase.iOS.AppCheck.targets" />
-    <None Include="AppCheck.targets" Pack="True" PackagePath="buildTransitive/AdamE.Firebase.iOS.AppCheck.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
     <None Include="../../../docs/Firebase/NuGet/AppCheck.md" Pack="True" PackagePath="NUGET_README.md" />
     <None Include="../../../icons/firebaseiosappcheck_128x128.png" Pack="True" PackagePath="firebaseiosappcheck_128x128.png" />

--- a/source/Firebase/AppCheck/AppCheck.targets
+++ b/source/Firebase/AppCheck/AppCheck.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_FirebaseAppCheckAssemblyName>Firebase.AppCheck, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_FirebaseAppCheckAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Firebase/Core/Core.csproj
+++ b/source/Firebase/Core/Core.csproj
@@ -36,8 +36,6 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>    
-    <None Include="Core.targets" Pack="True" PackagePath="build/AdamE.Firebase.iOS.Core.targets" />
-    <None Include="Core.targets" Pack="True" PackagePath="buildTransitive/AdamE.Firebase.iOS.Core.targets" />
     <None Include="External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
     <None Include="../../../docs/Firebase/NuGet/Core.md" Pack="True" PackagePath="NUGET_README.md" />

--- a/source/Firebase/Core/Core.targets
+++ b/source/Firebase/Core/Core.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_FirebaseCoreAssemblyName>Firebase.Core, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_FirebaseCoreAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Google/AppCheckCore/AppCheckCore.csproj
+++ b/source/Google/AppCheckCore/AppCheckCore.csproj
@@ -32,8 +32,6 @@
     <Compile Include="..\..\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="AppCheckCore.targets" Pack="True" PackagePath="build/AdamE.Google.iOS.AppCheckCore.targets" />
-    <None Include="AppCheckCore.targets" Pack="True" PackagePath="buildTransitive/AdamE.Google.iOS.AppCheckCore.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Google/AppCheckCore/AppCheckCore.targets
+++ b/source/Google/AppCheckCore/AppCheckCore.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_GoogleAppCheckCoreAssemblyName>Google.AppCheckCore, Version=11.2.0.0, Culture=neutral, PublicKeyToken=null</_GoogleAppCheckCoreAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Google/GTMSessionFetcher/GTMSessionFetcher.csproj
+++ b/source/Google/GTMSessionFetcher/GTMSessionFetcher.csproj
@@ -32,8 +32,6 @@
     <Compile Include="..\..\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>    
-    <None Include="GTMSessionFetcher.targets" Pack="True" PackagePath="build/AdamE.Google.iOS.GTMSessionFetcher.targets" />
-    <None Include="GTMSessionFetcher.targets" Pack="True" PackagePath="buildTransitive/AdamE.Google.iOS.GTMSessionFetcher.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
     <None Include="../../../docs/NUGET_README.md" Pack="True" PackagePath="NUGET_README.md" />
   </ItemGroup>

--- a/source/Google/GTMSessionFetcher/GTMSessionFetcher.targets
+++ b/source/Google/GTMSessionFetcher/GTMSessionFetcher.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_GTMSessionFetcherAssemblyName>Google.GTMSessionFetcher, Version=3.5.0.5, Culture=neutral, PublicKeyToken=null</_GTMSessionFetcherAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.csproj
@@ -31,8 +31,6 @@
     <Compile Include="..\..\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="GoogleAppMeasurement.targets" Pack="True" PackagePath="build/AdamE.Google.iOS.GoogleAppMeasurement.targets" />
-    <None Include="GoogleAppMeasurement.targets" Pack="True" PackagePath="buildTransitive/AdamE.Google.iOS.GoogleAppMeasurement.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets
+++ b/source/Google/GoogleAppMeasurement/GoogleAppMeasurement.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_GoogleAppMeasurementAssemblyName>Google.GoogleAppMeasurement, Version=12.10.0, Culture=neutral, PublicKeyToken=null</_GoogleAppMeasurementAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Google/GoogleDataTransport/GoogleDataTransport.csproj
+++ b/source/Google/GoogleDataTransport/GoogleDataTransport.csproj
@@ -31,8 +31,6 @@
     <Compile Include="..\..\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>    
-    <None Include="GoogleDataTransport.targets" Pack="True" PackagePath="build/AdamE.Google.iOS.GoogleDataTransport.targets" />
-    <None Include="GoogleDataTransport.targets" Pack="True" PackagePath="buildTransitive/AdamE.Google.iOS.GoogleDataTransport.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Google/GoogleDataTransport/GoogleDataTransport.targets
+++ b/source/Google/GoogleDataTransport/GoogleDataTransport.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_GoogleDataTransportAssemblyName>Google.GoogleDataTransport, Version=10.1.0.5, Culture=neutral, PublicKeyToken=null</_GoogleDataTransportAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Google/GoogleUtilities/GoogleUtilities.csproj
+++ b/source/Google/GoogleUtilities/GoogleUtilities.csproj
@@ -32,8 +32,6 @@
     <Compile Include="..\..\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>    
-    <None Include="GoogleUtilities.targets" Pack="True" PackagePath="build/AdamE.Google.iOS.GoogleUtilities.targets" />
-    <None Include="GoogleUtilities.targets" Pack="True" PackagePath="buildTransitive/AdamE.Google.iOS.GoogleUtilities.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
     <None Include="../../../docs/NUGET_README.md" Pack="True" PackagePath="NUGET_README.md" />
   </ItemGroup>

--- a/source/Google/GoogleUtilities/GoogleUtilities.targets
+++ b/source/Google/GoogleUtilities/GoogleUtilities.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_GoogleUtilitiesAssemblyName>Google.GoogleUtilities, Version=8.1.0.3, Culture=neutral, PublicKeyToken=null</_GoogleUtilitiesAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Google/Nanopb/Nanopb.csproj
+++ b/source/Google/Nanopb/Nanopb.csproj
@@ -31,8 +31,6 @@
     <Compile Include="..\..\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>    
-    <None Include="Nanopb.targets" Pack="True" PackagePath="build/AdamE.Google.iOS.Nanopb.targets" />
-    <None Include="Nanopb.targets" Pack="True" PackagePath="buildTransitive/AdamE.Google.iOS.Nanopb.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Google/Nanopb/Nanopb.targets
+++ b/source/Google/Nanopb/Nanopb.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_NanopbAssemblyName>Google.Nanopb, Version=3.30910.0.5, Culture=neutral, PublicKeyToken=null</_NanopbAssemblyName>
-  </PropertyGroup>
-</Project>

--- a/source/Google/PromisesObjC/PromisesObjC.csproj
+++ b/source/Google/PromisesObjC/PromisesObjC.csproj
@@ -32,8 +32,6 @@
     <Compile Include="..\..\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>    
-    <None Include="PromisesObjC.targets" Pack="True" PackagePath="build/AdamE.Google.iOS.PromisesObjC.targets" />
-    <None Include="PromisesObjC.targets" Pack="True" PackagePath="buildTransitive/AdamE.Google.iOS.PromisesObjC.targets" />
     <None Include="License.md" Pack="True" PackagePath="License.md" />
     <None Include="../../../docs/NUGET_README.md" Pack="True" PackagePath="NUGET_README.md" />
   </ItemGroup>

--- a/source/Google/PromisesObjC/PromisesObjC.targets
+++ b/source/Google/PromisesObjC/PromisesObjC.targets
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <_PromisesObjCAssemblyName>Google.PromisesObjC, Version=2.4.0.5, Culture=neutral, PublicKeyToken=null</_PromisesObjCAssemblyName>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
## Summary

- remove ten packaged `.targets` files that only assigned unused private assembly-name properties
- remove their corresponding `build/` and `buildTransitive/` pack entries
- remove the deleted Firebase target paths from the release updater
- leave every target file with executable, item, or import behavior unchanged

## Validation

- `dotnet tool restore`
- packed all ten affected components together with the repository Cake `nuget` target
- inspected all ten resulting NuGet archives and confirmed they contain no `.targets` entries
- built a Release `net10.0-ios` simulator consumer with direct references to all ten packages
- built a Release `net10.0-ios` simulator consumer through a class library with all ten packages present in the transitive asset graph
- compiled the Firebase release task graph with Cake `--dryrun` and verified its remaining managed target path exists

Both consumer builds completed with no package or linker errors.
